### PR TITLE
Refactor/module info 2

### DIFF
--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -3,7 +3,6 @@ module Opscode
     module Module
       module Helpers
         class ModuleInfo
-
           #
           # Given a key, which is a hash of criteria (i.e. module name, platform,
           # version, httpd_version), this method will return for you the package
@@ -44,7 +43,7 @@ module Opscode
           #
           def self.modules(options)
             options[:are].each do |mod|
-              key = options[:for].merge(module: mod)
+              key = options[:for].merge(:module => mod)
               modules_list[key] = options[:found_in_package].call(mod)
             end
           end
@@ -53,209 +52,207 @@ module Opscode
             @modules_list ||= {}
           end
 
-          modules for: { platform_family: "debian", httpd_version: "2.2" },
-            are: %w(
-              actions alias asis auth_basic auth_digest authn_alias authn_anon
-              authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
-              authz_default authz_groupfile authz_host authz_owner authz_user
-              autoindex cache cern_meta cgid cgi charset_lite dav_fs dav_lock dav
-              dbd deflate dir disk_cache dumpio env expires ext_filter file_cache
-              filter headers ident imagemap include info ldap log_forensic mem_cache
-              mime_magic mime negotiation proxy_ajp proxy_balancer proxy_connect
-              proxy_ftp proxy_http proxy_scgi proxy reqtimeout rewrite setenvif
-              speling ssl status substitute suexec unique_id userdir usertrack
-              vhost_alias
-            ),
-          found_in_package: -> (name) { "apache2" }
+          modules :for => { :platform_family => 'debian', :httpd_version => '2.2' },
+                  :are => %w(
+                    actions alias asis auth_basic auth_digest authn_alias authn_anon
+                    authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
+                    authz_default authz_groupfile authz_host authz_owner authz_user
+                    autoindex cache cern_meta cgid cgi charset_lite dav_fs dav_lock dav
+                    dbd deflate dir disk_cache dumpio env expires ext_filter file_cache
+                    filter headers ident imagemap include info ldap log_forensic mem_cache
+                    mime_magic mime negotiation proxy_ajp proxy_balancer proxy_connect
+                    proxy_ftp proxy_http proxy_scgi proxy reqtimeout rewrite setenvif
+                    speling ssl status substitute suexec unique_id userdir usertrack
+                    vhost_alias
+                  ),
+                  :found_in_package => -> (_name) { 'apache2' }
 
-          modules for: { platform_family: "debian", httpd_version: "2.2" },
-            are: %w(
-              apparmor apreq2 auth_cas auth_kerb auth_memcookie auth_mysql
-              auth_ntlm_winbind auth_openid auth_pam auth_pgsql auth_plain
-              auth_pubtkt auth_radius auth_sys_group auth_tkt authn_sasl authn_webid
-              authn_yubikey authnz_external authz_unixgroup bw dacs defensible dnssd
-              encoding evasive fcgid fcgid_dbg geoip gnutls jk layout ldap_userdir
-              ldap_userdir_dbg lisp log_sql log_sql_dbi log_sql_mysql log_sql_ssl
-              macro mime_xattr modsecurity mono musicindex neko nss ocamlnet parser3
-              passenger perl2 perl2_dev perl2_doc php5 php5filter proxy_html python
-              python_doc qos random removeip rivet rivet_doc rpaf ruby ruid2 ruwsgi
-              ruwsgi_dbg scgi shib2 spamhaus speedycgi suphp upload_progress uwsgi
-              uwsgi_dbg vhost_hash_alias vhost_ldap wsgi wsgi_py3 xsendfile
-            ),
-            found_in_package: -> (name) { "libapache2-mod-#{name.gsub('_','-')}" }
+          modules :for => { :platform_family => 'debian', :httpd_version => '2.2' },
+                  :are => %w(
+                    apparmor apreq2 auth_cas auth_kerb auth_memcookie auth_mysql
+                    auth_ntlm_winbind auth_openid auth_pam auth_pgsql auth_plain
+                    auth_pubtkt auth_radius auth_sys_group auth_tkt authn_sasl authn_webid
+                    authn_yubikey authnz_external authz_unixgroup bw dacs defensible dnssd
+                    encoding evasive fcgid fcgid_dbg geoip gnutls jk layout ldap_userdir
+                    ldap_userdir_dbg lisp log_sql log_sql_dbi log_sql_mysql log_sql_ssl
+                    macro mime_xattr modsecurity mono musicindex neko nss ocamlnet parser3
+                    passenger perl2 perl2_dev perl2_doc php5 php5filter proxy_html python
+                    python_doc qos random removeip rivet rivet_doc rpaf ruby ruid2 ruwsgi
+                    ruwsgi_dbg scgi shib2 spamhaus speedycgi suphp upload_progress uwsgi
+                    uwsgi_dbg vhost_hash_alias vhost_ldap wsgi wsgi_py3 xsendfile
+                  ),
+                  :found_in_package => -> (name) { "libapache2-mod-#{name.gsub('_', '-')}" }
 
-          modules for: { platform_family: "debian", httpd_version: "2.4" },
-            are: %w(
-                access_compat actions alias allowmethods asis auth_basic
-                auth_digest auth_form authn_anon authn_core authn_dbd authn_dbm
-                authn_file authn_socache authnz_ldap authz_core authz_dbd authz_dbm
-                authz_groupfile authz_host authz_owner authz_user autoindex buffer
-                cache cache_disk cache_socache cgi cgid charset_lite data dav
-                dav_fs dav_lock dbd deflate dialup dir dumpio echo env expires
-                ext_filter file_cache filter headers heartbeat heartmonitor include
-                info lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
-                lbmethod_heartbeat ldap log_debug log_forensic macro mime mime_magic
-                mpm_event mpm_prefork mpm_worker negotiation proxy proxy_ajp
-                proxy_balancer proxy_connect proxy_express proxy_fcgi proxy_fdpass
-                proxy_ftp proxy_html proxy_http proxy_scgi proxy_wstunnel ratelimit
-                reflector remoteip reqtimeout request rewrite sed session
-                session_cookie session_crypto session_dbd setenvif slotmem_plain
-                slotmem_shm socache_dbm socache_memcache socache_shmcb speling ssl
-                status substitute suexec unique_id userdir usertrack vhost_alias
-                xml2enc
-              ),
-            found_in_package: -> (name) { "apache2" }
+          modules :for => { :platform_family => 'debian', :httpd_version => '2.4' },
+                  :are => %w(
+                    access_compat actions alias allowmethods asis auth_basic
+                    auth_digest auth_form authn_anon authn_core authn_dbd authn_dbm
+                    authn_file authn_socache authnz_ldap authz_core authz_dbd authz_dbm
+                    authz_groupfile authz_host authz_owner authz_user autoindex buffer
+                    cache cache_disk cache_socache cgi cgid charset_lite data dav
+                    dav_fs dav_lock dbd deflate dialup dir dumpio echo env expires
+                    ext_filter file_cache filter headers heartbeat heartmonitor include
+                    info lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
+                    lbmethod_heartbeat ldap log_debug log_forensic macro mime mime_magic
+                    mpm_event mpm_prefork mpm_worker negotiation proxy proxy_ajp
+                    proxy_balancer proxy_connect proxy_express proxy_fcgi proxy_fdpass
+                    proxy_ftp proxy_html proxy_http proxy_scgi proxy_wstunnel ratelimit
+                    reflector remoteip reqtimeout request rewrite sed session
+                    session_cookie session_crypto session_dbd setenvif slotmem_plain
+                    slotmem_shm socache_dbm socache_memcache socache_shmcb speling ssl
+                    status substitute suexec unique_id userdir usertrack vhost_alias
+                    xml2enc
+                  ),
+                  :found_in_package => -> (_name) { 'apache2' }
 
-          modules for: { platform_family: "debian", httpd_version: "2.4" },
-            are: %w(
-                apparmor auth_mysql auth_pgsql auth_plain perl2 perl2_dev
-                perl2_doc php5 python python_doc wsgi reload_perl fastcgi
-                authcassimple_perl authcookie_perl authenntlm_perl apreq2 auth_cas
-                auth_kerb auth_mellon auth_memcookie auth_ntlm_winbind auth_openid
-                auth_pubtkt auth_radius auth_tkt authn_sasl authn_webid
-                authn_yubikey authnz_external authz_unixgroup axis2c bw dacs
-                defensible dnssd encoding evasive fcgid fcgid_dbg geoip gnutls jk
-                ldap_userdir ldap_userdir_dbg lisp log_slow log_sql log_sql_dbi
-                log_sql_mysql log_sql_ssl mapcache mime_xattr mono musicindex neko
-                netcgi_apache nss parser3 passenger php5filter qos removeip rivet
-                rivet_doc rpaf ruid2 ruwsgi ruwsgi_dbg scgi security2 shib2
-                spamhaus suphp svn upload_progress uwsgi uwsgi_dbg vhost_ldap
-                watchcat webauth webauthldap webkdc wsgi_py3 xsendfile modsecurity
-                mpm_itk request_perl sitecontrol_perl svn webauth webkdc
-              ),
-            found_in_package: -> (name) { "libapache2-mod-#{name.gsub('_','-')}" }
+          modules :for => { :platform_family => 'debian', :httpd_version => '2.4' },
+                  :are => %w(
+                    apparmor auth_mysql auth_pgsql auth_plain perl2 perl2_dev
+                    perl2_doc php5 python python_doc wsgi reload_perl fastcgi
+                    authcassimple_perl authcookie_perl authenntlm_perl apreq2 auth_cas
+                    auth_kerb auth_mellon auth_memcookie auth_ntlm_winbind auth_openid
+                    auth_pubtkt auth_radius auth_tkt authn_sasl authn_webid
+                    authn_yubikey authnz_external authz_unixgroup axis2c bw dacs
+                    defensible dnssd encoding evasive fcgid fcgid_dbg geoip gnutls jk
+                    ldap_userdir ldap_userdir_dbg lisp log_slow log_sql log_sql_dbi
+                    log_sql_mysql log_sql_ssl mapcache mime_xattr mono musicindex neko
+                    netcgi_apache nss parser3 passenger php5filter qos removeip rivet
+                    rivet_doc rpaf ruid2 ruwsgi ruwsgi_dbg scgi security2 shib2
+                    spamhaus suphp svn upload_progress uwsgi uwsgi_dbg vhost_ldap
+                    watchcat webauth webauthldap webkdc wsgi_py3 xsendfile modsecurity
+                    mpm_itk request_perl sitecontrol_perl svn webauth webkdc
+                  ),
+                  :found_in_package => -> (name) { "libapache2-mod-#{name.gsub('_', '-')}" }
 
-          modules for: { platform_family: "rhel", version: "5", httpd_version: "2.2" },
-            are: %w(
-              actions alias asis auth_basic auth_digest authn_alias authn_anon
-              authn_dbd authn_dbm authn_default authn_file authnz_ldap
-              authz_dbm authz_default authz_groupfile authz_host authz_owner
-              authz_user autoindex cache cern_meta cgi cgid dav dav_fs dbd deflate
-              dir disk_cache dumpio env expires ext_filter file_cache filter
-              headers ident imagemap include info ldap log_config log_forensic
-              logio mem_cache mime mime_magic negotiation proxy proxy proxy_ajp
-              proxy_balancer proxy_connect proxy_ftp proxy_http reqtimeout rewrite
-              setenvif speling status substitute suexec unique_id userdir
-              usertrack version vhost_alias
-            ),
-            found_in_package: -> (name) { "httpd" }
+          modules :for => { :platform_family => 'rhel', :version => '5', :httpd_version => '2.2' },
+                  :are => %w(
+                    actions alias asis auth_basic auth_digest authn_alias authn_anon
+                    authn_dbd authn_dbm authn_default authn_file authnz_ldap
+                    authz_dbm authz_default authz_groupfile authz_host authz_owner
+                    authz_user autoindex cache cern_meta cgi cgid dav dav_fs dbd deflate
+                    dir disk_cache dumpio env expires ext_filter file_cache filter
+                    headers ident imagemap include info ldap log_config log_forensic
+                    logio mem_cache mime mime_magic negotiation proxy proxy proxy_ajp
+                    proxy_balancer proxy_connect proxy_ftp proxy_http reqtimeout rewrite
+                    setenvif speling status substitute suexec unique_id userdir
+                    usertrack version vhost_alias
+                  ),
+                  :found_in_package => -> (_name) { 'httpd' }
 
-          modules for: { platform_family: "rhel", version: "5", httpd_version: "2.2" },
-            are: %w(
-              auth_mysql ssl auth_kerb auth_pgsql authz_ldap dav_svn mono nss
-              perl perl-devel perl-devel python revocator
-            ),
-            found_in_package: -> (name) { "mod_#{name}"}
+          modules :for => { :platform_family => 'rhel', :version => '5', :httpd_version => '2.2' },
+                  :are => %w(
+                    auth_mysql ssl auth_kerb auth_pgsql authz_ldap dav_svn mono nss
+                    perl perl-devel perl-devel python revocator
+                  ),
+                  :found_in_package => -> (name) { "mod_#{name}" }
 
-          modules for: { platform_family: "rhel", version: "6", httpd_version: "2.2" },
-            are: %w(
-              actions alias asis auth_basic auth_digest authn_alias authn_anon
-              authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
-              authz_default authz_groupfile authz_host authz_owner authz_user
-              autoindex cache cern_meta cgi cgid dav dav_fs dbd deflate dir
-              disk_cache dumpio env expires ext_filter filter headers ident
-              include info ldap log_config log_forensic logio mime mime_magic
-              negotiation proxy proxy proxy_ajp proxy_balancer proxy_connect
-              proxy_ftp proxy_http proxy_scgi reqtimeout rewrite setenvif speling
-              status substitute suexec unique_id userdir usertrack version
-              vhost_alias
-            ),
-            found_in_package: -> (name) { "httpd" }
+          modules :for => { :platform_family => 'rhel', :version => '6', :httpd_version => '2.2' },
+                  :are => %w(
+                    actions alias asis auth_basic auth_digest authn_alias authn_anon
+                    authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
+                    authz_default authz_groupfile authz_host authz_owner authz_user
+                    autoindex cache cern_meta cgi cgid dav dav_fs dbd deflate dir
+                    disk_cache dumpio env expires ext_filter filter headers ident
+                    include info ldap log_config log_forensic logio mime mime_magic
+                    negotiation proxy proxy proxy_ajp proxy_balancer proxy_connect
+                    proxy_ftp proxy_http proxy_scgi reqtimeout rewrite setenvif speling
+                    status substitute suexec unique_id userdir usertrack version
+                    vhost_alias
+                  ),
+                  :found_in_package => -> (_name) { 'httpd' }
 
-          modules for: { platform_family: "rhel", version: "6", httpd_version: "2.2" },
-            are: %w(
-              perl-devel perl-devel auth_kerb auth_mysql auth_pgsql authz_ldap
-              dav_svn dnssd nss perl revocator revocator ssl wsgi
-            ),
-            found_in_package: -> (name) { "mod_#{name}"}
+          modules :for => { :platform_family => 'rhel', :version => '6', :httpd_version => '2.2' },
+                  :are => %w(
+                    perl-devel perl-devel auth_kerb auth_mysql auth_pgsql authz_ldap
+                    dav_svn dnssd nss perl revocator revocator ssl wsgi
+                  ),
+                  :found_in_package => -> (name) { "mod_#{name}" }
 
-          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.2" },
-            are: %w(
-              actions alias asis auth_basic auth_digest authn_alias authn_anon
-              authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
-              authz_default authz_groupfile authz_host authz_owner authz_user
-              autoindex cache cern_meta cgi cgid dav dav_fs dbd deflate dir
-              disk_cache dumpio env expires ext_filter file_cache filter headers
-              ident include info ldap log_config log_forensic logio mime
-              mime_magic negotiation proxy proxy proxy_ajp proxy_balancer
-              proxy_connect proxy_ftp proxy_http proxy_scgi reqtimeout rewrite
-              setenvif speling status substitute suexec unique_id userdir
-              usertrack version vhost_alias
-            ),
-            found_in_package: -> (name) { "httpd" }
+          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.2' },
+                  :are => %w(
+                    actions alias asis auth_basic auth_digest authn_alias authn_anon
+                    authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
+                    authz_default authz_groupfile authz_host authz_owner authz_user
+                    autoindex cache cern_meta cgi cgid dav dav_fs dbd deflate dir
+                    disk_cache dumpio env expires ext_filter file_cache filter headers
+                    ident include info ldap log_config log_forensic logio mime
+                    mime_magic negotiation proxy proxy proxy_ajp proxy_balancer
+                    proxy_connect proxy_ftp proxy_http proxy_scgi reqtimeout rewrite
+                    setenvif speling status substitute suexec unique_id userdir
+                    usertrack version vhost_alias
+                  ),
+                  :found_in_package => -> (_name) { 'httpd' }
 
-          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.2" },
-            are: %w(
-              perl-devel security_crs-extras auth_kerb auth_mysql auth_pgsql
-              authz_ldap dav_svn fcgid geoip nss perl proxy_html python security
-              security_crs ssl wsgi
-            ),
-            found_in_package: -> (name) { "mod_#{name}" }
+          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.2' },
+                  :are => %w(
+                    perl-devel security_crs-extras auth_kerb auth_mysql auth_pgsql
+                    authz_ldap dav_svn fcgid geoip nss perl proxy_html python security
+                    security_crs ssl wsgi
+                  ),
+                  :found_in_package => -> (name) { "mod_#{name}" }
 
+          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.4' },
+                  :are => %w(
+                    access_compat actions alias allowmethods asis auth_basic
+                    auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
+                    authn_socache authz_core authz_dbd authz_dbm authz_groupfile
+                    authz_host authz_owner authz_user autoindex buffer cache cache_disk
+                    cache_socache cgi cgid charset_lite data dav dav_fs dav_lock dbd
+                    deflate dialup dir dumpio echo env expires ext_filter file_cache
+                    filter headers heartbeat heartmonitor include info
+                    lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
+                    lbmethod_heartbeat log_config log_debug log_forensic logio lua
+                    macro mime mime_magic mpm_event mpm_prefork mpm_worker negotiation
+                    proxy proxy_ajp proxy_balancer proxy_connect proxy_express
+                    proxy_fcgi proxy_fdpass proxy_ftp proxy_http proxy_scgi
+                    proxy_wstunnel ratelimit reflector remoteip reqtimeout request
+                    rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
+                    socache_memcache socache_shmcb speling status substitute suexec
+                    unique_id unixd userdir usertrack version vhost_alias watchdog
+                  ),
+                  :found_in_package => -> (_name) { 'httpd' }
 
-          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.4" },
-            are: %w(
-              access_compat actions alias allowmethods asis auth_basic
-              auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
-              authn_socache authz_core authz_dbd authz_dbm authz_groupfile
-              authz_host authz_owner authz_user autoindex buffer cache cache_disk
-              cache_socache cgi cgid charset_lite data dav dav_fs dav_lock dbd
-              deflate dialup dir dumpio echo env expires ext_filter file_cache
-              filter headers heartbeat heartmonitor include info
-              lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
-              lbmethod_heartbeat log_config log_debug log_forensic logio lua
-              macro mime mime_magic mpm_event mpm_prefork mpm_worker negotiation
-              proxy proxy_ajp proxy_balancer proxy_connect proxy_express
-              proxy_fcgi proxy_fdpass proxy_ftp proxy_http proxy_scgi
-              proxy_wstunnel ratelimit reflector remoteip reqtimeout request
-              rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
-              socache_memcache socache_shmcb speling status substitute suexec
-              unique_id unixd userdir usertrack version vhost_alias watchdog
-            ),
-            found_in_package: -> (name) { "httpd" }
+          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.4' },
+                  :are => %w(
+                    auth_kerb fcgid geoip ldap nss perl proxy_html security session
+                    ssl wsgi wsgi_py27
+                  ),
+                  :found_in_package => -> (name) { "mod_#{name}" }
 
-          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.4" },
-            are: %w(
-              auth_kerb fcgid geoip ldap nss perl proxy_html security session
-              ssl wsgi wsgi_py27
-            ),
-            found_in_package: -> (name) { "mod_#{name}" }
+          modules :for => { :platform_family => 'fedora', :version => '20', :httpd_version => '2.4' },
+                  :are => %w(
+                    access_compat actions alias allowmethods asis auth_basic
+                    auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
+                    authn_socache authz_core authz_dbd authz_dbm authz_groupfile
+                    authz_host authz_owner authz_user autoindex buffer cache cache_disk
+                    cache_socache cgi cgid charset_lite data dav dav_fs dav_lock dbd
+                    deflate dialup dir dumpio echo env expires ext_filter file_cache
+                    filter headers heartbeat heartmonitor include info
+                    lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
+                    lbmethod_heartbeat log_config log_debug log_forensic logio lua
+                    macro mime mime_magic mpm_event mpm_prefork mpm_worker negotiation
+                    proxy proxy_ajp proxy_balancer proxy_connect proxy_express
+                    proxy_fcgi proxy_fdpass proxy_ftp proxy_http proxy_scgi
+                    proxy_wstunnel ratelimit reflector remoteip reqtimeout request
+                    rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
+                    socache_memcache socache_shmcb speling status substitute suexec
+                    systemd unique_id unixd userdir usertrack version vhost_alias watchdog
+                  ),
+                  :found_in_package => -> (_name) { 'httpd' }
 
-          modules for: { platform_family: "fedora", version: "20", httpd_version: "2.4" },
-            are: %w(
-              access_compat actions alias allowmethods asis auth_basic
-              auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
-              authn_socache authz_core authz_dbd authz_dbm authz_groupfile
-              authz_host authz_owner authz_user autoindex buffer cache cache_disk
-              cache_socache cgi cgid charset_lite data dav dav_fs dav_lock dbd
-              deflate dialup dir dumpio echo env expires ext_filter file_cache
-              filter headers heartbeat heartmonitor include info
-              lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
-              lbmethod_heartbeat log_config log_debug log_forensic logio lua
-              macro mime mime_magic mpm_event mpm_prefork mpm_worker negotiation
-              proxy proxy_ajp proxy_balancer proxy_connect proxy_express
-              proxy_fcgi proxy_fdpass proxy_ftp proxy_http proxy_scgi
-              proxy_wstunnel ratelimit reflector remoteip reqtimeout request
-              rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
-              socache_memcache socache_shmcb speling status substitute suexec
-              systemd unique_id unixd userdir usertrack version vhost_alias watchdog
-            ),
-            found_in_package: -> (name) { "httpd" }
-
-          modules for: { platform_family: "fedora", version: "20", httpd_version: "2.4" },
-            are: %w(
-              annodex auth_cas auth_kerb auth_mellon auth_ntlm_winbind
-              authnz_external authnz_pam auth_token auth_xradius autoindex_mb
-              bw cluster cluster-java cluster-javadoc dav_svn dnssd evasive
-              fcgid flvx form form form-devel form-devel geoip gnutls
-              intercept_form_submit ldap limitipconn log_post lookup_identity
-              mirrorbrain nss passenger perl perl perl-devel perl-devel
-              proxy_html proxy_uwsgi qos revocator revocator security
-              security_crs security_crs-extras selinux session speedycgi ssl
-              suphp wsgi wso2-axis2 xsendfile
-            ),
-            found_in_package: -> (name) { "mod_#{name}" }
-
+          modules :for => { :platform_family => 'fedora', :version => '20', :httpd_version => '2.4' },
+                  :are => %w(
+                    annodex auth_cas auth_kerb auth_mellon auth_ntlm_winbind
+                    authnz_external authnz_pam auth_token auth_xradius autoindex_mb
+                    bw cluster cluster-java cluster-javadoc dav_svn dnssd evasive
+                    fcgid flvx form form form-devel form-devel geoip gnutls
+                    intercept_form_submit ldap limitipconn log_post lookup_identity
+                    mirrorbrain nss passenger perl perl perl-devel perl-devel
+                    proxy_html proxy_uwsgi qos revocator revocator security
+                    security_crs security_crs-extras selinux session speedycgi ssl
+                    suphp wsgi wso2-axis2 xsendfile
+                  ),
+                  :found_in_package => -> (name) { "mod_#{name}" }
         end
 
         def keyname_for(platform, platform_family, platform_version)
@@ -275,13 +272,11 @@ module Opscode
         end
 
         def package_name_for_module(name, httpd_version, platform, platform_family, platform_version)
-          ModuleInfo.find(platform_family: platform_family,
-            version: keyname_for(platform, platform_family, platform_version),
-            httpd_version: httpd_version,
-            module: name)
-
+          ModuleInfo.find(:platform_family => platform_family,
+                          :version => keyname_for(platform, platform_family, platform_version),
+                          :httpd_version => httpd_version,
+                          :module => name)
         end
-
       end
     end
   end

--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -46,7 +46,7 @@ module Opscode
                     speling ssl status substitute suexec unique_id userdir usertrack
                     vhost_alias
                   ),
-                  :found_in_package => -> (_name) { 'apache2' }
+                  :found_in_package => 'apache2'
 
           modules :for => { :platform_family => 'debian', :httpd_version => '2.2' },
                   :are => %w(
@@ -84,7 +84,7 @@ module Opscode
                     status substitute suexec unique_id userdir usertrack vhost_alias
                     xml2enc
                   ),
-                  :found_in_package => -> (_name) { 'apache2' }
+                  :found_in_package => 'apache2'
 
           modules :for => { :platform_family => 'debian', :httpd_version => '2.4' },
                   :are => %w(
@@ -118,7 +118,7 @@ module Opscode
                     setenvif speling status substitute suexec unique_id userdir
                     usertrack version vhost_alias
                   ),
-                  :found_in_package => -> (_name) { 'httpd' }
+                  :found_in_package => 'httpd'
 
           modules :for => { :platform_family => 'rhel', :version => '5', :httpd_version => '2.2' },
                   :are => %w(
@@ -140,7 +140,7 @@ module Opscode
                     status substitute suexec unique_id userdir usertrack version
                     vhost_alias
                   ),
-                  :found_in_package => -> (_name) { 'httpd' }
+                  :found_in_package => 'httpd'
 
           modules :for => { :platform_family => 'rhel', :version => '6', :httpd_version => '2.2' },
                   :are => %w(
@@ -162,7 +162,7 @@ module Opscode
                     setenvif speling status substitute suexec unique_id userdir
                     usertrack version vhost_alias
                   ),
-                  :found_in_package => -> (_name) { 'httpd' }
+                  :found_in_package => 'httpd'
 
           modules :for => { :platform => 'amazon', :version => '2014.03', :httpd_version => '2.2' },
                   :are => %w(
@@ -191,7 +191,7 @@ module Opscode
                     socache_memcache socache_shmcb speling status substitute suexec
                     unique_id unixd userdir usertrack version vhost_alias watchdog
                   ),
-                  :found_in_package => -> (_name) { 'httpd' }
+                  :found_in_package => 'httpd'
 
           modules :for => { :platform => 'amazon', :version => '2014.03', :httpd_version => '2.4' },
                   :are => %w(
@@ -219,7 +219,7 @@ module Opscode
                     socache_memcache socache_shmcb speling status substitute suexec
                     systemd unique_id unixd userdir usertrack version vhost_alias watchdog
                   ),
-                  :found_in_package => -> (_name) { 'httpd' }
+                  :found_in_package => 'httpd'
 
           modules :for => { :platform_family => 'fedora', :version => '20', :httpd_version => '2.4' },
                   :are => %w(

--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -3,8 +3,58 @@ module Opscode
     module Module
       module Helpers
         class ModuleInfo
-          def self.debian_2_2_core
-            %w(
+
+          #
+          # Given a key, which is a hash of criteria (i.e. module name, platform,
+          # version, httpd_version), this method will return for you the package
+          # where that module exists. `Nil` is returned if the key does not match
+          # any of the defined criteria.
+          #
+          # @example Searching for the 'alias' module on debian 10.04 with
+          #   httpd version 2.2
+          #
+          #     ModuleInfo.find(:module => 'alias', :platform_family => 'debian', :version => '10.04', :httpd_version: '2.2')
+          #
+          def self.find(key)
+            found_key = modules_list.keys.find { |lock| key.merge(lock) == key }
+            modules_list[found_key]
+          end
+
+          #
+          # Define what package stores a list of modules based on the any of the
+          # criteria: module platform_family, platform, version, httpd_version.
+          #
+          # @example Module 'ssl' on an Amazon 2014.03 instance using httpd version 2.4 can be found in the package 'mod_ssl'
+          #
+          #    modules for: { platform: "amazon", version: "2014.03", httpd_version: "2.4" },
+          #      are: [ "ssl" ], found_in_package: -> (name) { "mod_#{name}" }
+          #
+          # When defining the criteria you can specify as little or as much
+          # criteria you need. Not specifying the field means that field allows
+          # any value.
+          #
+          # @example Module 'alias' on an Debian instance using httpd version 2.2 can be found in the package 'apache2'
+          #
+          #    modules for: { platform_family: "debian", httpd_version: "2.2" },
+          #      are: [ "alias" ], found_in_package: -> (name) { "apache2" }
+          #
+          #
+          # This states that the 'alias' module is found on any version
+          # (e.g. 7, 10.04, 12.04) of Debian with httpd version 2.2.
+          #
+          def self.modules(options)
+            options[:are].each do |mod|
+              key = options[:for].merge(module: mod)
+              modules_list[key] = options[:found_in_package].call(mod)
+            end
+          end
+
+          def self.modules_list
+            @modules_list ||= {}
+          end
+
+          modules for: { platform_family: "debian", httpd_version: "2.2" },
+            are: %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
               authz_default authz_groupfile authz_host authz_owner authz_user
@@ -15,11 +65,11 @@ module Opscode
               proxy_ftp proxy_http proxy_scgi proxy reqtimeout rewrite setenvif
               speling ssl status substitute suexec unique_id userdir usertrack
               vhost_alias
-            )
-          end
+            ),
+          found_in_package: -> (name) { "apache2" }
 
-          def self.debian_2_2_other
-            %w(
+          modules for: { platform_family: "debian", httpd_version: "2.2" },
+            are: %w(
               apparmor apreq2 auth_cas auth_kerb auth_memcookie auth_mysql
               auth_ntlm_winbind auth_openid auth_pam auth_pgsql auth_plain
               auth_pubtkt auth_radius auth_sys_group auth_tkt authn_sasl authn_webid
@@ -31,52 +81,52 @@ module Opscode
               python_doc qos random removeip rivet rivet_doc rpaf ruby ruid2 ruwsgi
               ruwsgi_dbg scgi shib2 spamhaus speedycgi suphp upload_progress uwsgi
               uwsgi_dbg vhost_hash_alias vhost_ldap wsgi wsgi_py3 xsendfile
-            )
-          end
+            ),
+            found_in_package: -> (name) { "libapache2-mod-#{name.gsub('_','-')}" }
 
-          def self.debian_2_4_core
-            %w(
-              access_compat actions alias allowmethods asis auth_basic
-              auth_digest auth_form authn_anon authn_core authn_dbd authn_dbm
-              authn_file authn_socache authnz_ldap authz_core authz_dbd authz_dbm
-              authz_groupfile authz_host authz_owner authz_user autoindex buffer
-              cache cache_disk cache_socache cgi cgid charset_lite data dav
-              dav_fs dav_lock dbd deflate dialup dir dumpio echo env expires
-              ext_filter file_cache filter headers heartbeat heartmonitor include
-              info lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
-              lbmethod_heartbeat ldap log_debug log_forensic macro mime mime_magic
-              mpm_event mpm_prefork mpm_worker negotiation proxy proxy_ajp
-              proxy_balancer proxy_connect proxy_express proxy_fcgi proxy_fdpass
-              proxy_ftp proxy_html proxy_http proxy_scgi proxy_wstunnel ratelimit
-              reflector remoteip reqtimeout request rewrite sed session
-              session_cookie session_crypto session_dbd setenvif slotmem_plain
-              slotmem_shm socache_dbm socache_memcache socache_shmcb speling ssl
-              status substitute suexec unique_id userdir usertrack vhost_alias
-              xml2enc
-            )
-          end
+          modules for: { platform_family: "debian", httpd_version: "2.4" },
+            are: %w(
+                access_compat actions alias allowmethods asis auth_basic
+                auth_digest auth_form authn_anon authn_core authn_dbd authn_dbm
+                authn_file authn_socache authnz_ldap authz_core authz_dbd authz_dbm
+                authz_groupfile authz_host authz_owner authz_user autoindex buffer
+                cache cache_disk cache_socache cgi cgid charset_lite data dav
+                dav_fs dav_lock dbd deflate dialup dir dumpio echo env expires
+                ext_filter file_cache filter headers heartbeat heartmonitor include
+                info lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
+                lbmethod_heartbeat ldap log_debug log_forensic macro mime mime_magic
+                mpm_event mpm_prefork mpm_worker negotiation proxy proxy_ajp
+                proxy_balancer proxy_connect proxy_express proxy_fcgi proxy_fdpass
+                proxy_ftp proxy_html proxy_http proxy_scgi proxy_wstunnel ratelimit
+                reflector remoteip reqtimeout request rewrite sed session
+                session_cookie session_crypto session_dbd setenvif slotmem_plain
+                slotmem_shm socache_dbm socache_memcache socache_shmcb speling ssl
+                status substitute suexec unique_id userdir usertrack vhost_alias
+                xml2enc
+              ),
+            found_in_package: -> (name) { "apache2" }
 
-          def self.debian_2_4_other
-            %w(
-              apparmor auth_mysql auth_pgsql auth_plain perl2 perl2_dev
-              perl2_doc php5 python python_doc wsgi reload_perl fastcgi
-              authcassimple_perl authcookie_perl authenntlm_perl apreq2 auth_cas
-              auth_kerb auth_mellon auth_memcookie auth_ntlm_winbind auth_openid
-              auth_pubtkt auth_radius auth_tkt authn_sasl authn_webid
-              authn_yubikey authnz_external authz_unixgroup axis2c bw dacs
-              defensible dnssd encoding evasive fcgid fcgid_dbg geoip gnutls jk
-              ldap_userdir ldap_userdir_dbg lisp log_slow log_sql log_sql_dbi
-              log_sql_mysql log_sql_ssl mapcache mime_xattr mono musicindex neko
-              netcgi_apache nss parser3 passenger php5filter qos removeip rivet
-              rivet_doc rpaf ruid2 ruwsgi ruwsgi_dbg scgi security2 shib2
-              spamhaus suphp svn upload_progress uwsgi uwsgi_dbg vhost_ldap
-              watchcat webauth webauthldap webkdc wsgi_py3 xsendfile modsecurity
-              mpm_itk request_perl sitecontrol_perl svn webauth webkdc
-            )
-          end
+          modules for: { platform_family: "debian", httpd_version: "2.4" },
+            are: %w(
+                apparmor auth_mysql auth_pgsql auth_plain perl2 perl2_dev
+                perl2_doc php5 python python_doc wsgi reload_perl fastcgi
+                authcassimple_perl authcookie_perl authenntlm_perl apreq2 auth_cas
+                auth_kerb auth_mellon auth_memcookie auth_ntlm_winbind auth_openid
+                auth_pubtkt auth_radius auth_tkt authn_sasl authn_webid
+                authn_yubikey authnz_external authz_unixgroup axis2c bw dacs
+                defensible dnssd encoding evasive fcgid fcgid_dbg geoip gnutls jk
+                ldap_userdir ldap_userdir_dbg lisp log_slow log_sql log_sql_dbi
+                log_sql_mysql log_sql_ssl mapcache mime_xattr mono musicindex neko
+                netcgi_apache nss parser3 passenger php5filter qos removeip rivet
+                rivet_doc rpaf ruid2 ruwsgi ruwsgi_dbg scgi security2 shib2
+                spamhaus suphp svn upload_progress uwsgi uwsgi_dbg vhost_ldap
+                watchcat webauth webauthldap webkdc wsgi_py3 xsendfile modsecurity
+                mpm_itk request_perl sitecontrol_perl svn webauth webkdc
+              ),
+            found_in_package: -> (name) { "libapache2-mod-#{name.gsub('_','-')}" }
 
-          def self.rhel_5_2_2_core
-            %w(
+          modules for: { platform_family: "rhel", version: "5", httpd_version: "2.2" },
+            are: %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap
               authz_dbm authz_default authz_groupfile authz_host authz_owner
@@ -87,18 +137,18 @@ module Opscode
               proxy_balancer proxy_connect proxy_ftp proxy_http reqtimeout rewrite
               setenvif speling status substitute suexec unique_id userdir
               usertrack version vhost_alias
-            )
-          end
+            ),
+            found_in_package: -> (name) { "httpd" }
 
-          def self.rhel_5_2_2_other
-            %w(
+          modules for: { platform_family: "rhel", version: "5", httpd_version: "2.2" },
+            are: %w(
               auth_mysql ssl auth_kerb auth_pgsql authz_ldap dav_svn mono nss
               perl perl-devel perl-devel python revocator
-            )
-          end
+            ),
+            found_in_package: -> (name) { "mod_#{name}"}
 
-          def self.rhel_6_2_2_core
-            %w(
+          modules for: { platform_family: "rhel", version: "6", httpd_version: "2.2" },
+            are: %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
               authz_default authz_groupfile authz_host authz_owner authz_user
@@ -109,18 +159,18 @@ module Opscode
               proxy_ftp proxy_http proxy_scgi reqtimeout rewrite setenvif speling
               status substitute suexec unique_id userdir usertrack version
               vhost_alias
-            )
-          end
+            ),
+            found_in_package: -> (name) { "httpd" }
 
-          def self.rhel_6_2_2_other
-            %w(
+          modules for: { platform_family: "rhel", version: "6", httpd_version: "2.2" },
+            are: %w(
               perl-devel perl-devel auth_kerb auth_mysql auth_pgsql authz_ldap
               dav_svn dnssd nss perl revocator revocator ssl wsgi
-            )
-          end
+            ),
+            found_in_package: -> (name) { "mod_#{name}"}
 
-          def self.amazon_2_2_core
-            %w(
+          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.2" },
+            are: %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
               authz_default authz_groupfile authz_host authz_owner authz_user
@@ -131,19 +181,20 @@ module Opscode
               proxy_connect proxy_ftp proxy_http proxy_scgi reqtimeout rewrite
               setenvif speling status substitute suexec unique_id userdir
               usertrack version vhost_alias
-            )
-          end
+            ),
+            found_in_package: -> (name) { "httpd" }
 
-          def self.amazon_2_2_other
-            %w(
+          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.2" },
+            are: %w(
               perl-devel security_crs-extras auth_kerb auth_mysql auth_pgsql
               authz_ldap dav_svn fcgid geoip nss perl proxy_html python security
               security_crs ssl wsgi
-            )
-          end
+            ),
+            found_in_package: -> (name) { "mod_#{name}" }
 
-          def self.amazon_2_4_core
-            %w(
+
+          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.4" },
+            are: %w(
               access_compat actions alias allowmethods asis auth_basic
               auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
               authn_socache authz_core authz_dbd authz_dbm authz_groupfile
@@ -160,18 +211,18 @@ module Opscode
               rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
               socache_memcache socache_shmcb speling status substitute suexec
               unique_id unixd userdir usertrack version vhost_alias watchdog
-            )
-          end
+            ),
+            found_in_package: -> (name) { "httpd" }
 
-          def self.amazon_2_4_other
-            %w(
+          modules for: { platform_family: "rhel", version: "2014.03", httpd_version: "2.4" },
+            are: %w(
               auth_kerb fcgid geoip ldap nss perl proxy_html security session
               ssl wsgi wsgi_py27
-            )
-          end
+            ),
+            found_in_package: -> (name) { "mod_#{name}" }
 
-          def self.fedora_20_2_4_core
-            %w(
+          modules for: { platform_family: "fedora", version: "20", httpd_version: "2.4" },
+            are: %w(
               access_compat actions alias allowmethods asis auth_basic
               auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
               authn_socache authz_core authz_dbd authz_dbm authz_groupfile
@@ -188,11 +239,11 @@ module Opscode
               rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
               socache_memcache socache_shmcb speling status substitute suexec
               systemd unique_id unixd userdir usertrack version vhost_alias watchdog
-            )
-          end
+            ),
+            found_in_package: -> (name) { "httpd" }
 
-          def self.fedora_20_2_4_other
-            %w(
+          modules for: { platform_family: "fedora", version: "20", httpd_version: "2.4" },
+            are: %w(
               annodex auth_cas auth_kerb auth_mellon auth_ntlm_winbind
               authnz_external authnz_pam auth_token auth_xradius autoindex_mb
               bw cluster cluster-java cluster-javadoc dav_svn dnssd evasive
@@ -202,33 +253,9 @@ module Opscode
               proxy_html proxy_uwsgi qos revocator revocator security
               security_crs security_crs-extras selinux session speedycgi ssl
               suphp wsgi wso2-axis2 xsendfile
-            )
-          end
-        end
+            ),
+            found_in_package: -> (name) { "mod_#{name}" }
 
-        class MethodInfo
-          def self.method_info
-            @method_info ||= {
-              'debian' => {
-                '7' => { '2.2' => 'debian_2_2' },
-                'jessie' => { '2.4' => 'debian_2_4' },
-                '10.04' => { '2.2' => 'debian_2_2' },
-                '12.04' => { '2.2' => 'debian_2_2' },
-                '14.04' => { '2.4' => 'debian_2_4' }
-              },
-              'rhel' => {
-                '5' => { '2.2' => 'rhel_5_2_2' },
-                '6' => { '2.2' => 'rhel_6_2_2' },
-                '2014.03' => {
-                  '2.2' => 'amazon_2_2',
-                  '2.4' => 'amazon_2_4'
-                }
-              },
-              'fedora' => {
-                '20' => { '2.4' => 'fedora_20_2_4' }
-              }
-            }
-          end
         end
 
         def keyname_for(platform, platform_family, platform_version)
@@ -248,35 +275,13 @@ module Opscode
         end
 
         def package_name_for_module(name, httpd_version, platform, platform_family, platform_version)
-          # if platform == 'fedora'
-          #   require 'pry' ; binding.pry
-          # end
+          ModuleInfo.find(platform_family: platform_family,
+            version: keyname_for(platform, platform_family, platform_version),
+            httpd_version: httpd_version,
+            module: name)
 
-          keyname = keyname_for(platform, platform_family, platform_version)
-          method_name = MethodInfo.method_info[platform_family][keyname][httpd_version]
-
-          unless  method_name.nil?
-            case platform_family
-            when 'debian'
-              if ModuleInfo.send("#{method_name}_core").include? name
-                'apache2'
-              elsif ModuleInfo.send("#{method_name}_other").include? name
-                "libapache2-mod-#{name.gsub('_', '-')}"
-              else
-                nil
-              end
-            when /^(rhel|fedora)$/
-              if ModuleInfo.send("#{method_name}_core").include? name
-                'httpd'
-              elsif ModuleInfo.send("#{method_name}_other").include? name
-                "mod_#{name}"
-              else
-                nil
-              end
-            end
-
-          end
         end
+
       end
     end
   end

--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -4,7 +4,7 @@ module Opscode
       module Helpers
         class ModuleInfo
           def self.debian_2_2_core
-            debian_2_2_core = %w(
+            %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
               authz_default authz_groupfile authz_host authz_owner authz_user
@@ -19,7 +19,7 @@ module Opscode
           end
 
           def self.debian_2_2_other
-            debian_2_2_other = %w(
+            %w(
               apparmor apreq2 auth_cas auth_kerb auth_memcookie auth_mysql
               auth_ntlm_winbind auth_openid auth_pam auth_pgsql auth_plain
               auth_pubtkt auth_radius auth_sys_group auth_tkt authn_sasl authn_webid
@@ -35,7 +35,7 @@ module Opscode
           end
 
           def self.debian_2_4_core
-            debian_2_4_core = %w(
+            %w(
               access_compat actions alias allowmethods asis auth_basic
               auth_digest auth_form authn_anon authn_core authn_dbd authn_dbm
               authn_file authn_socache authnz_ldap authz_core authz_dbd authz_dbm
@@ -57,7 +57,7 @@ module Opscode
           end
 
           def self.debian_2_4_other
-            debian_2_4_other = %w(
+            %w(
               apparmor auth_mysql auth_pgsql auth_plain perl2 perl2_dev
               perl2_doc php5 python python_doc wsgi reload_perl fastcgi
               authcassimple_perl authcookie_perl authenntlm_perl apreq2 auth_cas
@@ -76,7 +76,7 @@ module Opscode
           end
 
           def self.rhel_5_2_2_core
-            rhel_5_2_2_core = %w(
+            %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap
               authz_dbm authz_default authz_groupfile authz_host authz_owner
@@ -91,14 +91,14 @@ module Opscode
           end
 
           def self.rhel_5_2_2_other
-            rhel_5_2_2_other = %w(
+            %w(
               auth_mysql ssl auth_kerb auth_pgsql authz_ldap dav_svn mono nss
               perl perl-devel perl-devel python revocator
             )
           end
 
           def self.rhel_6_2_2_core
-            rhel_6_2_2_core = %w(
+            %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
               authz_default authz_groupfile authz_host authz_owner authz_user
@@ -113,14 +113,14 @@ module Opscode
           end
 
           def self.rhel_6_2_2_other
-            rhel_6_2_2_other = %w(
+            %w(
               perl-devel perl-devel auth_kerb auth_mysql auth_pgsql authz_ldap
               dav_svn dnssd nss perl revocator revocator ssl wsgi
             )
           end
 
           def self.amazon_2_2_core
-            amazon_2_2_core = %w(
+            %w(
               actions alias asis auth_basic auth_digest authn_alias authn_anon
               authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
               authz_default authz_groupfile authz_host authz_owner authz_user
@@ -135,7 +135,7 @@ module Opscode
           end
 
           def self.amazon_2_2_other
-            amazon_2_2_other = %w(
+            %w(
               perl-devel security_crs-extras auth_kerb auth_mysql auth_pgsql
               authz_ldap dav_svn fcgid geoip nss perl proxy_html python security
               security_crs ssl wsgi
@@ -143,7 +143,7 @@ module Opscode
           end
 
           def self.amazon_2_4_core
-            amazon_2_4_core = %w(
+            %w(
               access_compat actions alias allowmethods asis auth_basic
               auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
               authn_socache authz_core authz_dbd authz_dbm authz_groupfile
@@ -164,14 +164,14 @@ module Opscode
           end
 
           def self.amazon_2_4_other
-            amazon_2_4_other = %w(
+            %w(
               auth_kerb fcgid geoip ldap nss perl proxy_html security session
               ssl wsgi wsgi_py27
             )
           end
 
           def self.fedora_20_2_4_core
-            fedora_20_2_4_core = %w(
+            %w(
               access_compat actions alias allowmethods asis auth_basic
               auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
               authn_socache authz_core authz_dbd authz_dbm authz_groupfile
@@ -192,7 +192,7 @@ module Opscode
           end
 
           def self.fedora_20_2_4_other
-            fedora_20_2_4_other = %w(
+            %w(
               annodex auth_cas auth_kerb auth_mellon auth_ntlm_winbind
               authnz_external authnz_pam auth_token auth_xradius autoindex_mb
               bw cluster cluster-java cluster-javadoc dav_svn dnssd evasive

--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -265,17 +265,7 @@ module Opscode
               else
                 nil
               end
-
-            when 'rhel'
-              if ModuleInfo.send("#{method_name}_core").include? name
-                'httpd'
-              elsif ModuleInfo.send("#{method_name}_other").include? name
-                "mod_#{name}"
-              else
-                nil
-              end
-
-            when 'fedora'
+            when /^(rhel|fedora)$/
               if ModuleInfo.send("#{method_name}_core").include? name
                 'httpd'
               elsif ModuleInfo.send("#{method_name}_other").include? name
@@ -284,6 +274,7 @@ module Opscode
                 nil
               end
             end
+
           end
         end
       end

--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -232,30 +232,19 @@ module Opscode
         end
 
         def keyname_for(platform, platform_family, platform_version)
-          case
-          when platform_family == 'rhel'
-            platform == 'amazon' ? platform_version : platform_version.to_i.to_s
-          when platform_family == 'suse'
+          if platform_family == 'rhel' and platform != 'amazon'
+            major_version(platform_version)
+          elsif platform_family == 'debian' and !(platform == 'ubuntu' or platform_version =~ /sid$/)
+            major_version(platform_version)
+          elsif platform_family == 'freebsd'
+            major_version(platform_version)
+          else
             platform_version
-          when platform_family == 'fedora'
-            platform_version
-          when platform_family == 'debian'
-            if platform == 'ubuntu'
-              platform_version
-            elsif platform_version =~ /sid$/
-              platform_version
-            else
-              platform_version.to_i.to_s
-            end
-          when platform_family == 'smartos'
-            platform_version
-          when platform_family == 'omnios'
-            platform_version
-          when platform_family == 'freebsd'
-            platform_version.to_i.to_s
           end
-        rescue NoMethodError
-          nil
+        end
+
+        def major_version(version)
+          version.to_i.to_s
         end
 
         def package_name_for_module(name, httpd_version, platform, platform_family, platform_version)

--- a/libraries/module_info.rb
+++ b/libraries/module_info.rb
@@ -168,7 +168,7 @@ module Opscode
                   ),
                   :found_in_package => -> (name) { "mod_#{name}" }
 
-          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.2' },
+          modules :for => { :platform => 'amazon', :version => '2014.03', :httpd_version => '2.2' },
                   :are => %w(
                     actions alias asis auth_basic auth_digest authn_alias authn_anon
                     authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
@@ -183,7 +183,7 @@ module Opscode
                   ),
                   :found_in_package => -> (_name) { 'httpd' }
 
-          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.2' },
+          modules :for => { :platform => 'amazon', :version => '2014.03', :httpd_version => '2.2' },
                   :are => %w(
                     perl-devel security_crs-extras auth_kerb auth_mysql auth_pgsql
                     authz_ldap dav_svn fcgid geoip nss perl proxy_html python security
@@ -191,7 +191,7 @@ module Opscode
                   ),
                   :found_in_package => -> (name) { "mod_#{name}" }
 
-          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.4' },
+          modules :for => { :platform => 'amazon', :version => '2014.03', :httpd_version => '2.4' },
                   :are => %w(
                     access_compat actions alias allowmethods asis auth_basic
                     auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
@@ -212,7 +212,7 @@ module Opscode
                   ),
                   :found_in_package => -> (_name) { 'httpd' }
 
-          modules :for => { :platform_family => 'rhel', :version => '2014.03', :httpd_version => '2.4' },
+          modules :for => { :platform => 'amazon', :version => '2014.03', :httpd_version => '2.4' },
                   :are => %w(
                     auth_kerb fcgid geoip ldap nss perl proxy_html security session
                     ssl wsgi wsgi_py27
@@ -272,10 +272,11 @@ module Opscode
         end
 
         def package_name_for_module(name, httpd_version, platform, platform_family, platform_version)
-          ModuleInfo.find(:platform_family => platform_family,
-                          :version => keyname_for(platform, platform_family, platform_version),
+          ModuleInfo.find(:module => name,
                           :httpd_version => httpd_version,
-                          :module => name)
+                          :platform => platform,
+                          :platform_family => platform_family,
+                          :version => keyname_for(platform, platform_family, platform_version))
         end
       end
     end

--- a/libraries/module_info_dsl.rb
+++ b/libraries/module_info_dsl.rb
@@ -45,7 +45,11 @@ module Opscode
           def modules(options)
             options[:are].each do |mod|
               key = options[:for].merge(:module => mod)
-              modules_list[key] = options[:found_in_package].call(mod)
+
+              package = options[:found_in_package]
+              package = package.call(mod) if package.is_a?(Proc)
+
+              modules_list[key] = package
             end
           end
 

--- a/libraries/module_info_dsl.rb
+++ b/libraries/module_info_dsl.rb
@@ -1,0 +1,60 @@
+module Opscode
+  module Httpd
+    module Module
+      module Helpers
+
+        module ModuleInfoDSL
+          #
+          # Given a key, which is a hash of criteria (i.e. module name, platform,
+          # version, httpd_version), this method will return for you the package
+          # where that module exists. `Nil` is returned if the key does not match
+          # any of the defined criteria.
+          #
+          # @example Searching for the 'alias' module on debian 10.04 with
+          #   httpd version 2.2
+          #
+          #     ModuleInfo.find(:module => 'alias', :platform_family => 'debian', :version => '10.04', :httpd_version: '2.2')
+          #
+          def find(key)
+            found_key = modules_list.keys.find { |lock| key.merge(lock) == key }
+            modules_list[found_key]
+          end
+
+          #
+          # Define what package stores a list of modules based on the any of the
+          # criteria: module platform_family, platform, version, httpd_version.
+          #
+          # @example Module 'ssl' on an Amazon 2014.03 instance using httpd version 2.4 can be found in the package 'mod_ssl'
+          #
+          #    modules for: { platform: "amazon", version: "2014.03", httpd_version: "2.4" },
+          #      are: [ "ssl" ], found_in_package: -> (name) { "mod_#{name}" }
+          #
+          # When defining the criteria you can specify as little or as much
+          # criteria you need. Not specifying the field means that field allows
+          # any value.
+          #
+          # @example Module 'alias' on an Debian instance using httpd version 2.2 can be found in the package 'apache2'
+          #
+          #    modules for: { platform_family: "debian", httpd_version: "2.2" },
+          #      are: [ "alias" ], found_in_package: -> (name) { "apache2" }
+          #
+          #
+          # This states that the 'alias' module is found on any version
+          # (e.g. 7, 10.04, 12.04) of Debian with httpd version 2.2.
+          #
+          def modules(options)
+            options[:are].each do |mod|
+              key = options[:for].merge(:module => mod)
+              modules_list[key] = options[:found_in_package].call(mod)
+            end
+          end
+
+          def modules_list
+            @modules_list ||= {}
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/helpers/module_debian_2_2_spec.rb
+++ b/spec/helpers/module_debian_2_2_spec.rb
@@ -5,7 +5,7 @@ describe 'looking up module package name' do
     extend Opscode::Httpd::Module::Helpers
   end
 
-  context 'for apache 2.2 on debian 7' do
+  context 'for apache 2.2 on debian 7, 10.04, and 12.04' do
     debian_2_2_core = %w(
       actions alias asis auth_basic auth_digest authn_alias authn_anon
       authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
@@ -37,6 +37,12 @@ describe 'looking up module package name' do
       it 'returns the proper package name' do
         expect(
           package_name_for_module(m, '2.2', 'debian', 'debian', '7.2')
+          ).to eq('apache2')
+        expect(
+          package_name_for_module(m, '2.2', 'debian', 'debian', '10.04')
+          ).to eq('apache2')
+        expect(
+          package_name_for_module(m, '2.2', 'debian', 'debian', '12.04')
           ).to eq('apache2')
       end
     end


### PR DESCRIPTION
This is the more destructive changes to the original implementation. This provides a DSL for defining where modules are supported. The good things about the implementation is that if you leave off something like "version", then it assumes all versions. This is useful for say Debian where all the modules are the same across all the versions.

This hopefully creates the more  flexible/readable interface you were hoping for in this section of code.

``` ruby
modules for: { platform_family: "debian", httpd_version: "2.2" },
  are: %w(
    actions alias asis auth_basic auth_digest authn_alias authn_anon
    authn_dbd authn_dbm authn_default authn_file authnz_ldap authz_dbm
    authz_default authz_groupfile authz_host authz_owner authz_user
    autoindex cache cern_meta cgid cgi charset_lite dav_fs dav_lock dav
    dbd deflate dir disk_cache dumpio env expires ext_filter file_cache
    filter headers ident imagemap include info ldap log_forensic mem_cache
    mime_magic mime negotiation proxy_ajp proxy_balancer proxy_connect
    proxy_ftp proxy_http proxy_scgi proxy reqtimeout rewrite setenvif
    speling ssl status substitute suexec unique_id userdir usertrack
    vhost_alias
  ),
found_in_package: "apache2"
```
