### PR TITLE
FIX: Httpd::Module::Helpers::ModuleDetails Specs

### DIFF
--- a/libraries/module_details_dsl.rb
+++ b/libraries/module_details_dsl.rb
@@ -14,7 +14,7 @@ module Httpd
         end
 
         def after_installing(options)
-          key = options[:on].merge(:module => options[:module])
+          key = options[:on].merge(:package => options[:package])
           actions = options[:chef_should]
           module_details_data[key] = actions
         end

--- a/spec/helpers/module_details_rhel_spec.rb
+++ b/spec/helpers/module_details_rhel_spec.rb
@@ -2,78 +2,77 @@ require_relative '../../libraries/module_details_rhel.rb'
 require_relative '../../libraries/module_details_dsl.rb'
 
 describe 'looking up module package name' do
-  before do
-    extend Httpd::Module::Helpers::ModuleDetailsDSL
-  end
+
+  let(:subject) { Httpd::Module::Helpers::ModuleDetails }
 
   context 'for apache 2.2 on rhel-5' do
     # auth_kerb for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_auth_kerb', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_auth_kerb', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/auth_kerb.conf'])
     end
 
     # auth_mysql for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_auth_mysql', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_auth_mysql', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/auth_mysql.conf'])
     end
 
     # auth_psql for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_auth_psql', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_auth_psql', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/auth_psql.conf'])
     end
 
     # authz_ldap for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_authz_ldap', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_authz_ldap', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/authz_ldap.conf'])
     end
 
     # dav_svn for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_dav_svn', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_dav_svn', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/subversion.conf'])
     end
 
     # nss for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_nss', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_nss', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/nss.conf'])
     end
 
     # perl for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_perl', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_perl', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/perl.conf'])
     end
 
     # python for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_python', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_python', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/python.conf'])
     end
 
     # revocator for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_revocator', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_revocator', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/revocator.conf'])
     end
 
     # ssl for 2.2 on rhel-5
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_ssl', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
+        subject.find_deletes(:package => 'mod_ssl', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '5')
         ).to eq(['/etc/httpd/conf.d/ssl.conf'])
     end
   end
@@ -82,63 +81,63 @@ describe 'looking up module package name' do
     # auth_kerb for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_auth_kerb', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_auth_kerb', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/auth_kerb.conf'])
     end
 
     # auth_mysql for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_auth_mysql', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_auth_mysql', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/auth_mysql.conf'])
     end
 
     # authz_ldap for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_authz_ldap', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_authz_ldap', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/authz_ldap.conf'])
     end
 
     # dav_svn for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_dav_svn', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_dav_svn', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/subversion.conf'])
     end
 
     # dnssd for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_dnssd', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_dnssd', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/mod_dnssd.conf'])
     end
 
     # nss for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_nss', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_nss', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/nss.conf'])
     end
 
     # perl for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_perl', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_perl', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/perl.conf'])
     end
 
     # revocator for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_revocator', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_revocator', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/revocator.conf'])
     end
 
     # wsgi for 2.2 on rhel-6
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_wsgi', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
+        subject.find_deletes(:package => 'mod_wsgi', :httpd_version => '2.2', :platform => 'centos', :platform_family => 'rhel', :platform_version => '6')
         ).to eq(['/etc/httpd/conf.d/wsgi.conf'])
     end
   end
@@ -147,77 +146,80 @@ describe 'looking up module package name' do
     # auth_kerb for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_auth_kerb', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_auth_kerb', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.modules.d/10-auth_kerb.conf'])
     end
 
     # dav_svn for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_dav_svn', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_dav_svn', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.modules.d/10-subversion.conf'])
     end
 
     # fcgid for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_fcgid', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_fcgid', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.d/fcgid.conf', '/etc/httpd/conf.modules.d/10-fcgid.conf'])
     end
 
     # ldap for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_ldap', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_ldap', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.modules.d/01-ldap.conf'])
     end
 
     # nss for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_nss', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_nss', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.d/nss.conf', '/etc/httpd/conf.modules.d/10-nss.conf'])
     end
 
     # proxy_html for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_proxy_html', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_proxy_html', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.modules.d/00-proxyhtml.conf'])
     end
 
     # revocator for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_revocator', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_revocator', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.d/revocator.conf', '/etc/httpd/conf.modules.d/11-revocator.conf'])
     end
 
     # security for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_security', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_security', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.d/mod_security.conf', '/etc/httpd/conf.modules.d/10-mod_security.conf'])
     end
 
     # session for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_session', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_session', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.modules.d/01-session.conf'])
     end
 
     # ssl for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_ssl', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_ssl', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.d/ssl.conf', '/etc/httpd/conf.modules.d/00-ssl.conf'])
     end
+
+
 
     # wsgi for 2.4 on rhel-7
     it 'returns the proper list of files to delete' do
       expect(
-        find_deletes(:package => 'mod_wsgi', :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
+        subject.find_deletes(:package => 'mod_wsgi',
+          :httpd_version => '2.4', :platform => 'centos', :platform_family => 'rhel', :platform_version => '7')
         ).to eq(['/etc/httpd/conf.modules.d/10-wsgi.conf'])
     end
   end


### PR DESCRIPTION
Instead of extending the Httpd::Module::Helpers::ModuleDetails which added the DSL methods to the spec context object (whatever that is at the moment of the execution of the specs), I instead use the ModuleDetails object that was defined. Adding these methods to a new object, in this case the spec context object, does not carry over any of the data defined/stored on Httpd::Module::Helpers::ModuleDetails.

I used a rspec let helper to define a subject and set that to the name of the module we care about testing for the information and then updated all the specs to call the `find_deletes` on that class.

Lastly, there was one small typo where you were looking for **module** but all the entries were using **package**.
