### PR TITLE
More fixes for Fedora and RHEL

### DIFF
--- a/libraries/helpers_rhel.rb
+++ b/libraries/helpers_rhel.rb
@@ -71,10 +71,10 @@ module Httpd
       def include_optionals
         return unless new_resource.parsed_version.to_f >= 2.4
         include_optionals = [
-          'conf.d/*.conf',
-          'conf.d/*.load',
           'conf.modules.d/*.conf',
-          'conf.modules.d/*.load'
+          'conf.modules.d/*.load',
+          'conf.d/*.conf',
+          'conf.d/*.load'
         ]
         include_optionals
       end

--- a/libraries/module_package_info.rb
+++ b/libraries/module_package_info.rb
@@ -201,7 +201,7 @@ module Httpd
         # predictable package naming
         modules for: { platform_family: 'rhel', platform_version: '7', httpd_version: '2.4' },
                 are: %w(
-                  auth_kerb dav_svn fcgid ldap nss proxy_html revocator security
+                  auth_kerb dav_svn fcgid ldap nss proxy_html revocator
                   session ssl wsgi
                 ),
                 found_in_package: ->(name) { "mod_#{name}" }
@@ -222,6 +222,10 @@ module Httpd
         modules for: { platform_family: 'rhel', platform_version: '7', httpd_version: '2.4' },
                 are: %w(rev),
                 found_in_package: ->(_name) { 'mod_revocator' }
+
+        modules for: { platform_family: 'rhel', platform_version: '7', httpd_version: '2.4' },
+                are: %w(security2),
+                found_in_package: ->(_name) { 'mod_security' }
 
         modules for: { platform_family: 'rhel', platform_version: '7', httpd_version: '2.4' },
                 are: %w(auth_form session_cookie session_crypto session_dbd),
@@ -254,7 +258,7 @@ module Httpd
         # predictable package naming
         modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
                 are: %w(
-                  auth_kerb dav_svn fcgid ldap nss proxy_html revocator security
+                  auth_kerb dav_svn fcgid ldap nss proxy_html revocator
                   session ssl wsgi
                 ),
                 found_in_package: ->(name) { "mod_#{name}" }
@@ -275,6 +279,10 @@ module Httpd
         modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
                 are: %w(rev),
                 found_in_package: ->(_name) { 'mod_revocator' }
+
+        modules for: { platform_family: 'fedora', platform_version: '21', httpd_server: '2.4' },
+                are: %w(security2),
+                found_in_package: ->(_name) { 'mod_security' }
 
         modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
                 are: %w(auth_form session_cookie session_crypto session_dbd),

--- a/libraries/resource_httpd_module.rb
+++ b/libraries/resource_httpd_module.rb
@@ -21,10 +21,10 @@ class Chef
       def parsed_filename
         return filename if filename
         # Put all exceptions here
-        if node['platform_family'] == 'rhel'
+        if node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora'
           return 'libmodnss.so' if module_name == 'nss'
           return 'mod_rev.so' if module_name == 'revocator'
-          return 'libphp5.so' if module_name == 'php'
+          return 'libphp5-zts.so' if module_name == 'php5' # XXX problem: need to return 'libphp5.so' if prefork, otherwise the ZTS version
         end
         "mod_#{module_name}.so"
       end


### PR DESCRIPTION
Here are a few more fixes for RHEL 7 and Fedora 21.
- The 'security' module is provided by the package 'mod_security' even though everywhere it's referred to as security2.
- I'm not quite sure what to do about PHP. If running under a prefork MPM, the appropriate .so to load is libphp5.so; otherwise it's libphp5-zts.so. For now I've hardcoded it to the latter since this cookbook defaults to the event MPM but this could use some more thought.
