### PR TITLE
Fixed bug in listen_addresses resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -55,3 +55,6 @@ suites:
     attributes:
       httpd:
         version: '2.4'
+        listen_addresses: [
+          '0.0.0.0'
+        ]

--- a/libraries/resource_httpd_service.rb
+++ b/libraries/resource_httpd_service.rb
@@ -10,7 +10,7 @@ class Chef
       attribute :instance, kind_of: String, name_attribute: true
       attribute :keepalive, kind_of: [TrueClass, FalseClass], default: true
       attribute :keepalivetimeout, kind_of: String, default: '5'
-      attribute :listen_addresses, kind_of: String, default: ['0.0.0.0']
+      attribute :listen_addresses, kind_of: [String, Array], default: ['0.0.0.0']
       attribute :listen_ports, kind_of: [String, Array], default: %w(80)
       attribute :log_level, kind_of: String, default: 'warn'
       attribute :maxclients, kind_of: String, default: nil

--- a/templates/default/httpd.conf.erb
+++ b/templates/default/httpd.conf.erb
@@ -49,7 +49,7 @@ HostnameLookups <%= @config.hostname_lookups %>
 Listen <%= port %>
 <%   end %>
 <% else %>
-<%   @config.listen_addresses.each do |address| %>
+<%   Array(@config.listen_addresses).each do |address| %>
 <%     @config.listen_ports.each do |port| %>
 Listen <%= address %>:<%= port %>
 <%     end %>


### PR DESCRIPTION
This fixes a bug with the httpd_service resource where listen_addresses could not be set.  I don't really love this solution as it pushes some minor logic to the template, but given the alternative of duplicating the code in all the providers this seemed like the lesser of 2 evils
