### PR TITLE
Fix `instance` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ HTTPD Cookbook
 
 The HTTPD Cookbook is a Library Cookbook that provides resource
 primitives for use in recipes. It is designed to be an example to
-reference for creating highly re-usable cross platform cookbooks. 
+reference for creating highly re-usable cross platform cookbooks.
 
 Scope
 -----
@@ -106,19 +106,19 @@ configurations.
     httpd_service 'default' do
       action :create
     end
-    
+
     httpd_service 'instance-1' do
       listen_ports ['81', '82']
       action :create
     end
-    
+
     httpd_service 'an websites' do
       instance_name 'bob'
       servername 'www.computers.biz'
       version '2.4'
       mpm 'event'
       threadlimit '4096'
-      listen_ports ['1234']      
+      listen_ports ['1234']
       action :create
     end
 
@@ -136,16 +136,16 @@ http://httpd.apache.org/docs/2.4/mod/directives.html
  instance. By convention,  this will result in configuration, log, and
  support directories being created and used in the form
  '/etc/instance-name', '/var/log/instance-name', etc. If set to
- 'default', the platform native defaults are used. 
+ 'default', the platform native defaults are used.
 
 - `keepalive` - Enables HTTP persistent connections. Values can be true or false.
 
 - `keepalivetimeout` -  Amount of time the server will wait for
-  subsequent requests on a persistent connection. 
-  
+  subsequent requests on a persistent connection.
+
 - `listen_addresses` - IP addresses that the server listens to.
   Defaults to ['0.0.0.0'].
-  
+
 - `listen_ports` - Ports that the server listens to. Defaults to
   ['80', '443'].  
 
@@ -153,70 +153,70 @@ http://httpd.apache.org/docs/2.4/mod/directives.html
 
 - `maxclients` - Maximum number of connections that will be processed
   simultaneously. Valid only with prefork and worker MPMs.
-  
+
 - `maxconnectionsperchild` - Limit on the number of connections that
   an individual child server will handle during its life. Valid with
   Apache 2.4 prefork, worker and event MPMs.
-  
+
 - `maxkeepaliverequests` - Number of requests allowed on a persistent
   connection. Defaults to 100.
-  
+
 - `maxrequestsperchild` -  The Apache 2.2 version of
   maxconnectionsperchild. Still supported as of 2.4  
- 
+
 - `maxrequestworkers` - Maximum number of connections that will be
   processed simultaneously. Valid on prefork, worker, and event MPMs.
-   
+
 - `maxspareservers` - Maximum number of idle child server processes.
   Valid only for prefork MPM.
-  
+
 - `maxsparethreads` - Maximum number of idle threads. Valid only for
   worker and event MPMs.
-  
+
 - `minspareservers` - Minimum number of idle child server processes.
   Valid only for preform MPM.
-  
+
 - `minsparethreads` - Minimum number of idle threads available to
   handle request spikes. Valid only for worker and event MPMs.  
 
 - `modules` - A list of initial Apache modules to be loaded inside the
   httpd_service instance. Defaults to Debian standard on 2.2 and 2.4.
-  
+
 - `mpm` - The Multi-Processing Module to use for the `httpd_service`
   instance. Values can be 'prefork', 'worker', and 'event'. Defaults
   to 'worker' for Apache 2.2 and 'event' for Apache 2.4.
-  
+
 - `package_name` - Name of the server package to install on the
 machine using the system package manager. Defaults to 'apache2' on
 Debian and 'httpd' on RHEL.
 
 - `run_group` - System group to start the `httpd_service` as. Defaults
   to 'www-data' on Debian and 'apache' on RHEL.
-  
+
 - `run_user` - System user to start the `httpd_service` as. Defaults
   to 'www-data' on Debian and 'apache' on RHEL.
-  
+
 - `servername` - Hostname and port that the server uses to identify
   itself. Syntax: [scheme://]fully-qualified-domain-name[:port].
   Defaults to node['hostname'].
-  
+
 - `startservers` - Number of child server processes created at
   startup. Valid for prefork, worker, and event MPMs. Default value
   differs from MPM to MPM.
-  
+
 - `threadlimit` - Sets the upper limit on the configurable number of
   threads per child process. Valid on worker and event MPMs.
-  
+
 - `threadsperchild` - Number of threads created by each child process.
   Valid on worker and event MPMs.  
 
 - `timeout` - Amount of time the server will wait for certain events
   before failing a request. Defaults to '400'
-  
+
 - `version` - Apache software version to use. Available options are
   '2.2', and '2.4', depending on platform. Defaults to latest
   available.
-  
+
 ### httpd_module
 The `httpd_module` resource is responsible ensuring that an Apache
 module is installed on the system, as well as ensuring a load configuration
@@ -227,17 +227,17 @@ snippet is dropped off at the appropriate location.
     httpd_module 'ssl' do
       action :create
     end
-    
+
     httpd_module 'el dap' do
       module_name 'ldap'
       action :create
     end
-    
+
     httpd_module 'auth_pgsql' do
-      httpd_instance 'instance-2'
+      instance 'instance-2'
       action :create
     end
-    
+
 #### Parameters
 - `filename` - The filename of the shared object to be rendered into
   the load config snippet. This can usually be omitted, and defaults
@@ -247,12 +247,12 @@ snippet is dropped off at the appropriate location.
   meant to be installed for. Useful on platforms that support multiple
   Apache versions. Defaults to the platform default.
 
-- `instance` - The `httpd_service` name to drop the load snippet off 
+- `instance` - The `httpd_service` name to drop the load snippet off
 for. Defaults to 'default'.
 
 - `module_name` - The module name to install. Defaults to the
   `httpd_module` name.
-  
+
 
 `package_name` - The package name the module is found in. By default,
 this is looked up in an internal map.
@@ -268,14 +268,14 @@ the instance parameter to calculate where the config is dropped off.
       source 'mysite.erb'
       action :create
     end
-    
+
     httpd_config 'computers dot biz ssl_config' do
       config_name 'ssl-config'
       httpd_instance 'computers_dot_biz'
       source 'ssl_config.erb'
       action :create
     end
-    
+
 #### Parameters
 - `config_name` - The name of the config on disk
 
@@ -284,10 +284,10 @@ the instance parameter to calculate where the config is dropped off.
 
 - `httpd_version` - Used to calculate the configuration's disk path.
   Defaults to the platform's native Apache version.
-  
+
 - `instance` - The `httpd_service` instance the config is meant for.
   Defaults to 'default'
-  
+
 - `source` - The ERB format template source used to render the file.
 
 - `variables` - A hash of variables passed to the underlying template


### PR DESCRIPTION
It looks like this resource method was renamed, but the documentation doesn't reflect it entirely.
