### PR TITLE
Install httpd modules with yum only if they don't yet exist on disk

### DIFF
--- a/libraries/provider_httpd_module_rhel.rb
+++ b/libraries/provider_httpd_module_rhel.rb
@@ -22,7 +22,7 @@ class Chef
           # package_name is set by resource
           package "#{new_resource.name} :create #{parsed_module_package_name}" do
             package_name parsed_module_package_name
-            action :install
+            action ::File.exists?(module_path) ? :nothing : :install
           end
 
           # 2.2 vs 2.4


### PR DESCRIPTION
First check if a module is already on disk before we attempt to install it by package name.  On CentOS 7, mod_proxy and mod_proxy_fcgi are shipped by default, and do not have corresponding packages, so attempting to load them via `httpd_module` fails otherwise.
