### PR TITLE
Fix config load order

### DIFF
--- a/libraries/helpers_rhel.rb
+++ b/libraries/helpers_rhel.rb
@@ -43,10 +43,10 @@ module HttpdCookbook
       def include_optionals
         return unless parsed_version.to_f >= 2.4
         [
-          'conf.d/*.conf',
           'conf.d/*.load',
-          'conf.modules.d/*.conf',
-          'conf.modules.d/*.load'
+          'conf.d/*.conf',
+          'conf.modules.d/*.load',
+          'conf.modules.d/*.conf'
         ]
       end
     end


### PR DESCRIPTION
On Apache 2.4 on CentOS 7, any module configs in /etc/httpd-default/conf.modules.d that use `<IfModule ...>` do not load correctly.  This is because the *.conf files are loaded before the modules are loaded in the *.load files.  This PR simply sets the order correctly.  I've confirmed that in a standard Apache 2.4 install in Ubuntu, the same order is set (.load, then .conf).
