### PR TITLE
Allow adding directives to httpd.conf by hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ Debian and 'httpd' on RHEL.
 - `timeout` - Amount of time the server will wait for certain events
   before failing a request. Defaults to '400'
 
+- `extra_options` - Hash that will be sent directly to the httpd.conf template in
+  the form of `key = value`. This can be used to add additional directives to your
+  configuration.
+
 - `version` - Apache software version to use. Available options are
   '2.2', and '2.4', depending on platform. Defaults to latest
   available.

--- a/libraries/provider_httpd_service_debian.rb
+++ b/libraries/provider_httpd_service_debian.rb
@@ -236,7 +236,8 @@ class Chef
               run_group: parsed_run_group,
               run_user: parsed_run_user,
               server_root: "/etc/#{apache_name}",
-              servername: parsed_servername
+              servername: parsed_servername,
+              extra_options: new_resource.extra_options
               )
             cookbook 'httpd'
             action :create

--- a/libraries/provider_httpd_service_rhel.rb
+++ b/libraries/provider_httpd_service_rhel.rb
@@ -236,7 +236,8 @@ class Chef
               run_group: parsed_run_group,
               run_user: parsed_run_user,
               server_root: "/etc/#{apache_name}",
-              servername: parsed_servername
+              servername: parsed_servername,
+              extra_options: new_resource.extra_options
               )
             cookbook 'httpd'
             action :create

--- a/libraries/resource_httpd_service.rb
+++ b/libraries/resource_httpd_service.rb
@@ -35,6 +35,7 @@ class Chef
       attribute :threadsperchild, kind_of: String, default: nil
       attribute :timeout, kind_of: String, default: '400'
       attribute :version, kind_of: String, default: nil
+      attribute :extra_options, kind_of: Hash, default: nil
     end
   end
 end

--- a/templates/default/httpd.conf.erb
+++ b/templates/default/httpd.conf.erb
@@ -58,7 +58,7 @@ Listen <%= address %>:<%= port %>
 
 <% if @extra_options %>
 <%   @extra_options.each do |directive,value| %>
-<%=    directive %> = <%= value %>
+<%=    directive %> <%= value %>
 <%   end %>
 <% end %>
 

--- a/templates/default/httpd.conf.erb
+++ b/templates/default/httpd.conf.erb
@@ -56,6 +56,12 @@ Listen <%= address %>:<%= port %>
 <%   end %>
 <% end %>
 
+<% if @extra_options %>
+<%   @extra_options.each do |directive,value| %>
+<%=    directive %> = <%= value %>
+<%   end %>
+<% end %>
+
 <% if @includes %>
 <%  @includes.each do |i| %>
 Include <%= i %>


### PR DESCRIPTION
This PR grew out of the need to update TypesConfig.  I didn't want to use a custom template (or use the  line cookbook) just for a one-line addition.  Anyway, this allows you to pass in a hash to the template, which gets written out in the form of `key = value`.  This should be helpful to those who need to make custom changes to httpd.conf without having to do a lot of extra work for it.