### PR TITLE
Adding a helper for Ubuntu specifically for mod_php

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -49,6 +49,9 @@ module HttpdCookbook
         return 'libphp5.so' if module_name == 'php'
         return 'libphp5-zts.so' if module_name == 'php-zts'
       end
+      if node['platform_family'] == 'debian'
+        return 'libphp5.so' if module_name == 'php5'
+      end
       "mod_#{module_name}.so"
     end
 


### PR DESCRIPTION
For debian and ubuntu the packages do not name the shared object as mod_php5:

https://packages.debian.org/jessie/amd64/libapache2-mod-php5/filelist
https://packages.debian.org/wheezy/amd64/libapache2-mod-php5/filelist

http://packages.ubuntu.com/trusty/amd64/libapache2-mod-php5/filelist
http://packages.ubuntu.com/precise/amd64/libapache2-mod-php5/filelist

Updating the helper to identify this as it does for rhel.
