### PR TITLE
fix PHP filename on Debian

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,7 +45,7 @@ module HttpdCookbook
       # Put all exceptions here
       case node['platform_family']
       when 'debian'
-        return 'libphp5.so' if %w(php5 php).include? module_name
+        return 'libphp5.so' if module_name == 'php5'
       when 'rhel'
         return 'libmodnss.so' if module_name == 'nss'
         return 'mod_rev.so' if module_name == 'revocator'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -43,7 +43,10 @@ module HttpdCookbook
     def parsed_filename
       return new_resource.filename if new_resource.filename
       # Put all exceptions here
-      if node['platform_family'] == 'rhel'
+      case node['platform_family']
+      when 'debian'
+        return 'libphp5.so' if %w(php5 php).include? module_name
+      when 'rhel'
         return 'libmodnss.so' if module_name == 'nss'
         return 'mod_rev.so' if module_name == 'revocator'
         return 'libphp5.so' if module_name == 'php'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'httpd'
-version '0.2.12'
+version '0.2.13'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'


### PR DESCRIPTION
Before this change, `/etc/apache2-<sitename>/mods-enabled/php5.load` gets written as:

```
LoadModule php5_module /usr/lib/apache2/modules/php5.so
```

This change ensures that the correct file name is written out:

```
LoadModule php5_module /usr/lib/apache2/modules/libphp5.so
```
