### PR TITLE
re-organize the includes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
 platforms:
   - name: centos-5.11
   - name: centos-6.6
+  - name: centos-7.0
   - name: fedora-21
   - name: ubuntu-10.04
     run_list:
@@ -48,6 +49,7 @@ suites:
     - recipe[httpd_service_test::single]
     includes: [
       'amazon-2014.03',
+      'centos-7.0',
       'fedora-21',
       'smartos-13.4.0',
       'ubuntu-14.04',

--- a/libraries/helpers_debian.rb
+++ b/libraries/helpers_debian.rb
@@ -40,8 +40,8 @@ module HttpdCookbook
       def includes
         return unless apache_version.to_f < 2.4
         [
-          'conf.d/*.conf',
           'mods-enabled/*.load',
+          'conf.d/*.conf',
           'mods-enabled/*.conf'
         ]
       end
@@ -49,8 +49,8 @@ module HttpdCookbook
       def include_optionals
         return unless apache_version.to_f >= 2.4
         [
-          'conf-enabled/*.conf',
           'mods-enabled/*.load',
+          'conf-enabled/*.conf',
           'mods-enabled/*.conf',
           'sites-enabled/*.conf'
         ]

--- a/libraries/helpers_rhel.rb
+++ b/libraries/helpers_rhel.rb
@@ -35,8 +35,8 @@ module HttpdCookbook
       def includes
         return unless parsed_version.to_f < 2.4
         [
-          'conf.d/*.conf',
-          'conf.d/*.load'
+          'conf.d/*.load',
+          'conf.d/*.conf'
         ]
       end
 
@@ -44,8 +44,8 @@ module HttpdCookbook
         return unless parsed_version.to_f >= 2.4
         [
           'conf.d/*.load',
-          'conf.d/*.conf',
           'conf.modules.d/*.load',
+          'conf.d/*.conf',
           'conf.modules.d/*.conf'
         ]
       end


### PR DESCRIPTION
this PR re-organizes the includes in order to load modules (\*.load) before configs (\*.conf) in order to enable the use of [IfModule](http://httpd.apache.org/docs/2.2/mod/core.html#ifmodule) in httpd_config templates.

presently, using IfModule does not work, because the config is loaded and evaluated before the module is present.