### PR TITLE
Smart Provider Resolver support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
 platforms:
   - name: centos-5.11
   - name: centos-6.6
+  - name: centos-7.1
   - name: fedora-21
   - name: ubuntu-10.04
     run_list:
@@ -51,6 +52,7 @@ suites:
       'fedora-21',
       'smartos-13.4.0',
       'ubuntu-14.04',
+      'centos-7.1',
     ]
     attributes:
       httpd:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ other httpd server implementations like Lighttpd, Nginx, or IIS.
 
 Requirements
 ------------
-- Chef 11 or higher
+- Chef 12.0.0 or higher
 - Ruby 1.9 or higher (preferably from the Chef full-stack installer)
 - Network accessible package repositories
 

--- a/libraries/provider_httpd_config_debian.rb
+++ b/libraries/provider_httpd_config_debian.rb
@@ -6,10 +6,10 @@ class Chef
   class Provider
     class HttpdConfig
       class Debian < Chef::Provider::HttpdConfig
-        provides :httpd_config, platform_family: 'debian' if respond_to?(:provides)
-        provides :httpd_config, platform_family: 'ubuntu' if respond_to?(:provides)
+        provides :httpd_config, platform_family: 'debian'
+        provides :httpd_config, platform_family: 'ubuntu'
 
-        use_inline_resources if defined?(use_inline_resources)
+        use_inline_resources
 
         def whyrun_supported?
           true

--- a/libraries/provider_httpd_config_rhel.rb
+++ b/libraries/provider_httpd_config_rhel.rb
@@ -6,11 +6,11 @@ class Chef
   class Provider
     class HttpdConfig
       class Rhel < Chef::Provider::HttpdConfig
-        provides :httpd_config, platform_family: 'rhel' if respond_to?(:provides)
-        provides :httpd_config, platform_family: 'fedora' if respond_to?(:provides)
-        provides :httpd_config, platform_family: 'suse' if respond_to?(:provides)
+        provides :httpd_config, platform_family: 'rhel'
+        provides :httpd_config, platform_family: 'fedora'
+        provides :httpd_config, platform_family: 'suse'
 
-        use_inline_resources if defined?(use_inline_resources)
+        use_inline_resources
 
         def whyrun_supported?
           true

--- a/libraries/provider_httpd_module_debian.rb
+++ b/libraries/provider_httpd_module_debian.rb
@@ -5,10 +5,10 @@ class Chef
   class Provider
     class HttpdModule
       class Debian < Chef::Provider::HttpdModule
-        provides :httpd_module, platform_family: 'debian' if respond_to?(:provides)
-        provides :httpd_module, platform_family: 'ubuntu' if respond_to?(:provides)
+        provides :httpd_module, platform_family: 'debian'
+        provides :httpd_module, platform_family: 'ubuntu'
 
-        use_inline_resources if defined?(use_inline_resources)
+        use_inline_resources
 
         def whyrun_supported?
           true

--- a/libraries/provider_httpd_module_rhel.rb
+++ b/libraries/provider_httpd_module_rhel.rb
@@ -5,11 +5,11 @@ class Chef
   class Provider
     class HttpdModule
       class Rhel < Chef::Provider::HttpdModule
-        provides :httpd_module, platform_family: 'rhel' if respond_to?(:provides)
-        provides :httpd_module, platform_family: 'fedora' if respond_to?(:provides)
-        provides :httpd_module, platform_family: 'suse' if respond_to?(:provides)
+        provides :httpd_module, platform_family: 'rhel'
+        provides :httpd_module, platform_family: 'fedora'
+        provides :httpd_module, platform_family: 'suse'
 
-        use_inline_resources if defined?(use_inline_resources)
+        use_inline_resources
 
         def whyrun_supported?
           true

--- a/libraries/provider_httpd_service_debian.rb
+++ b/libraries/provider_httpd_service_debian.rb
@@ -5,7 +5,7 @@ class Chef
   class Provider
     class HttpdService
       class Debian < Chef::Provider::HttpdService
-        use_inline_resources if defined?(use_inline_resources)
+        use_inline_resources
 
         def whyrun_supported?
           true

--- a/libraries/provider_httpd_service_debian_sysvinit.rb
+++ b/libraries/provider_httpd_service_debian_sysvinit.rb
@@ -6,10 +6,10 @@ class Chef
     class HttpdService
       class Debian < Chef::Provider::HttpdService
         class Sysvinit < Chef::Provider::HttpdService::Debian
-          provides :httpd_service, platform_family: 'debian' if respond_to?(:provides)
-          provides :httpd_service, platform_family: 'ubuntu' if respond_to?(:provides)
+          provides :httpd_service, platform_family: 'debian'
+          provides :httpd_service, platform_family: 'ubuntu'
 
-          use_inline_resources if defined?(use_inline_resources)
+          use_inline_resources
 
           def whyrun_supported?
             true

--- a/libraries/provider_httpd_service_rhel.rb
+++ b/libraries/provider_httpd_service_rhel.rb
@@ -5,7 +5,7 @@ class Chef
   class Provider
     class HttpdService
       class Rhel < Chef::Provider::HttpdService
-        use_inline_resources if defined?(use_inline_resources)
+        use_inline_resources
 
         def whyrun_supported?
           true

--- a/libraries/provider_httpd_service_rhel_systemd.rb
+++ b/libraries/provider_httpd_service_rhel_systemd.rb
@@ -6,14 +6,18 @@ class Chef
     class HttpdService
       class Rhel
         class Systemd < Chef::Provider::HttpdService::Rhel
-          #
-          # Amazon is in the "rhel" platform_family and doesn't play nice.
-          # And so, we have to use platform instead.
-          provides :httpd_service, platform: 'fedora' if respond_to?(:provides)
-          provides :httpd_service, platform: 'oracle' if respond_to?(:provides)
-          provides :httpd_service, platform: %w(redhat centos scientific) do |node|
-            node[:platform_version].to_f >= 7.0
-          end if respond_to?(:provides)
+          if respond_to?(:provides)
+            # This is Chef-12.0.0 back-compat, it is different from current core chef 12.4.0 declarations
+            provides :httpd_service, platform_family: 'rhel'
+
+            def self.provides?(node, resource)
+              super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
+            end
+
+            def self.supports?(resource, action)
+              Chef::Platform::ServiceHelpers.config_for_service("httpd-#{resource.instance}").include?(:systemd)
+            end
+          end
 
           use_inline_resources if defined?(use_inline_resources)
 

--- a/libraries/provider_httpd_service_rhel_systemd.rb
+++ b/libraries/provider_httpd_service_rhel_systemd.rb
@@ -6,20 +6,18 @@ class Chef
     class HttpdService
       class Rhel
         class Systemd < Chef::Provider::HttpdService::Rhel
-          if respond_to?(:provides)
-            # This is Chef-12.0.0 back-compat, it is different from current core chef 12.4.0 declarations
-            provides :httpd_service, platform_family: 'rhel'
+          # This is Chef-12.0.0 back-compat, it is different from current core chef 12.4.0 declarations
+          provides :httpd_service, platform_family: 'rhel'
 
-            def self.provides?(node, resource)
-              super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
-            end
-
-            def self.supports?(resource, action)
-              Chef::Platform::ServiceHelpers.config_for_service("httpd-#{resource.instance}").include?(:systemd)
-            end
+          def self.provides?(node, resource)
+            super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:systemd)
           end
 
-          use_inline_resources if defined?(use_inline_resources)
+          def self.supports?(resource, action)
+            Chef::Platform::ServiceHelpers.config_for_service("httpd-#{resource.instance}").include?(:systemd)
+          end
+
+          use_inline_resources
 
           def whyrun_supported?
             true

--- a/libraries/provider_httpd_service_rhel_sysvinit.rb
+++ b/libraries/provider_httpd_service_rhel_sysvinit.rb
@@ -6,13 +6,18 @@ class Chef
     class HttpdService
       class Rhel
         class Sysvinit < Chef::Provider::HttpdService::Rhel
-          #
-          # Amazon is in the "rhel" platform_family and doesn't play nice.
-          # And so, we have to use platform instead.
-          provides :httpd_service, platform: 'amazon' if respond_to?(:provides)
-          provides :httpd_service, platform: 'centos' if respond_to?(:provides)
-          provides :httpd_service, platform: 'redhat' if respond_to?(:provides)
-          provides :httpd_service, platform: 'suse' if respond_to?(:provides)
+          if respond_to?(:provides)
+            # This is Chef-12.0.0 back-compat, it is different from current core chef 12.4.0 declarations
+            provides :httpd_service, platform_family: 'rhel'
+
+            def self.provides?(node, resource)
+              super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:redhat)
+            end
+
+            def self.supports?(resource, action)
+              Chef::Platform::ServiceHelpers.config_for_service("httpd-#{resource.instance}").include?(:initd)
+            end
+          end
 
           use_inline_resources if defined?(use_inline_resources)
 

--- a/libraries/provider_httpd_service_rhel_sysvinit.rb
+++ b/libraries/provider_httpd_service_rhel_sysvinit.rb
@@ -6,20 +6,18 @@ class Chef
     class HttpdService
       class Rhel
         class Sysvinit < Chef::Provider::HttpdService::Rhel
-          if respond_to?(:provides)
-            # This is Chef-12.0.0 back-compat, it is different from current core chef 12.4.0 declarations
-            provides :httpd_service, platform_family: 'rhel'
+          # This is Chef-12.0.0 back-compat, it is different from current core chef 12.4.0 declarations
+          provides :httpd_service, platform_family: 'rhel'
 
-            def self.provides?(node, resource)
-              super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:redhat)
-            end
-
-            def self.supports?(resource, action)
-              Chef::Platform::ServiceHelpers.config_for_service("httpd-#{resource.instance}").include?(:initd)
-            end
+          def self.provides?(node, resource)
+            super && Chef::Platform::ServiceHelpers.service_resource_providers.include?(:redhat)
           end
 
-          use_inline_resources if defined?(use_inline_resources)
+          def self.supports?(resource, action)
+            Chef::Platform::ServiceHelpers.config_for_service("httpd-#{resource.instance}").include?(:initd)
+          end
+
+          use_inline_resources
 
           def whyrun_supported?
             true

--- a/libraries/provider_priority_rhel.rb
+++ b/libraries/provider_priority_rhel.rb
@@ -1,0 +1,11 @@
+require 'chef/platform/provider_priority_map'
+require_relative 'provider_httpd_service_rhel_systemd'
+require_relative 'provider_httpd_service_rhel_sysvinit'
+
+if defined? Chef::Platform::ProviderPriorityMap
+  Chef::Platform::ProviderPriorityMap.instance.set_priority_array(
+    :service,
+    [ Chef::Provider::HttpdService::Rhel::Systemd,  Chef::Provider::HttpdService::Rhel::Sysvinit ],
+    platform_family: 'rhel',
+  )
+end

--- a/libraries/provider_priority_rhel.rb
+++ b/libraries/provider_priority_rhel.rb
@@ -3,7 +3,7 @@ require_relative 'provider_httpd_service_rhel_systemd'
 require_relative 'provider_httpd_service_rhel_sysvinit'
 
 if defined? Chef::Platform::ProviderPriorityMap
-  Chef::Platform::ProviderPriorityMap.instance.set_priority_array(
+  Chef::Platform::ProviderPriorityMap.instance.priority(
     :service,
     [ Chef::Provider::HttpdService::Rhel::Systemd,  Chef::Provider::HttpdService::Rhel::Sysvinit ],
     platform_family: 'rhel',


### PR DESCRIPTION
tested on 12.2.1 and 12.4.0, should work on 12.x
- deliberately does not use the 12.3.0-specific Chef.class stuff
- deliberately does not use the 12.4.0-specific node_map improvements

test on centos6 and centos7, added a TK suite for centos7
