### PR TITLE
Support Amazon Linux AMI 2015.03

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -28,6 +28,7 @@ module HttpdCookbook
       return '2.4' if node['platform_family'] == 'fedora'
       return '2.4' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 2013
       return '2.4' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 2014
+      return '2.4' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 2015
       return '2.4' if node['platform_family'] == 'rhel' && node['platform_version'].to_i == 7
       return '2.4' if node['platform_family'] == 'smartos'
     end

--- a/libraries/helpers_rhel.rb
+++ b/libraries/helpers_rhel.rb
@@ -21,6 +21,7 @@ module HttpdCookbook
       def elversion
         return 6 if node['platform_version'].to_i == 2013
         return 6 if node['platform_version'].to_i == 2014
+        return 6 if node['platform_version'].to_i == 2015
         return 7 if node['platform_version'].to_i == 20
         return 7 if node['platform_version'].to_i == 21
         node['platform_version'].to_i

--- a/libraries/info_module_packages.rb
+++ b/libraries/info_module_packages.rb
@@ -443,6 +443,10 @@ module HttpdCookbook
       modules for: { platform: 'amazon', httpd_version: '2.4' },
               are: %w(auth_form session_cookie session_crypto session_dbd),
               found_in_package: ->(_name) { 'mod_session' }
+
+      modules for: { platform: 'amazon', platform_version: '2015.03', httpd_version: '2.4' },
+              are: %w(php),
+              found_in_package: ->(_name) { 'php56' }
     end
 
     def platform_version_key(platform, platform_family, platform_version)


### PR DESCRIPTION
- Add helper entries to find the right httpd package version.
- Add entry to `ModuleInfo` to find the right PHP package.

I did not update any of the tests. I also didn't update `kitchen.cloud.yml` - it seems a bit out of date and I didn't want to touch it right now.
