### PR TITLE
Create run directories on reboot for Apache instances

### DIFF
--- a/libraries/httpd_service_rhel_systemd.rb
+++ b/libraries/httpd_service_rhel_systemd.rb
@@ -49,11 +49,11 @@ module HttpdCookbook
         group 'root'
         mode '0644'
         cookbook 'httpd'
-        variables({
+        variables(
           apache_name: apache_name,
           run_user: run_user,
           run_group: run_group
-          })
+        )
       end
 
       service "#{apache_name}" do

--- a/libraries/httpd_service_rhel_systemd.rb
+++ b/libraries/httpd_service_rhel_systemd.rb
@@ -43,6 +43,19 @@ module HttpdCookbook
         action :create
       end
 
+      template "/usr/lib/tmpfiles.d/#{apache_name}.conf" do
+        source 'systemd/httpd.conf.erb'
+        owner 'root'
+        group 'root'
+        mode '0644'
+        cookbook 'httpd'
+        variables({
+          apache_name: apache_name,
+          run_user: run_user,
+          run_group: run_group
+          })
+      end
+
       service "#{apache_name}" do
         supports restart: true, reload: true, status: true
         provider Chef::Provider::Service::Init::Systemd

--- a/templates/default/systemd/httpd.conf.erb
+++ b/templates/default/systemd/httpd.conf.erb
@@ -1,0 +1,2 @@
+d /run/httpd-<%= @apache_name %>   710 root <%= @run_user %>
+d /run/httpd-<%= @apache_name %>/htcacheclean   700 <%= @run_user %> <%= @run_group %>


### PR DESCRIPTION
### Environment:
Centos 7

### Scenario:
Have the ability to start custom and default created Apache instance post reboot. The cookbook currently creates the needed run dir during the lifecycle of the chef run, however in Centos 7 this is not persistent.

### Steps to reproduce:
Run a basic install of httpd default instance or multiple instances on a Centos 7 image and reboot. It results in lack of run directory to create pid file in.

### Testing performed:
Ran through kitchen test for all platforms and passed
Verified creation of desired files on assorted docker centos-7 containers
Tested tmpfiles.d concept and that it survives a reboot

### Other Information
We may want to look into the directive " RuntimeDirectory" in the systemd service file in the future , however it seems that the default Apache install does in fact create a /usr/lib/tmpfiles.d/httpd.conf which ensures run directory creation upon boot

I am creating this pull request without test as it seems you cannot do a converge test cycle that involves more than the lifetime of a test instance. ( Much appreciated for thom in #chef-hacking for that information ) This test would require a reboot of the system in order to fully test functionality.
