### PR TITLE
Fix invalid default value warnings

### DIFF
--- a/libraries/httpd_config.rb
+++ b/libraries/httpd_config.rb
@@ -1,11 +1,11 @@
 module HttpdCookbook
   class HttpdConfig < ChefCompat::Resource
     property :config_name, String, name_property: true, required: true
-    property :cookbook, String, default: nil
+    property :cookbook, [String, nil], default: nil
     property :httpd_version, String, default: lazy { default_apache_version }
     property :instance, String, default: 'default'
-    property :source, String, default: nil
-    property :variables, [Hash], default: nil
+    property :source, [String, nil], default: nil
+    property :variables, [Hash], default: {}
 
     include HttpdCookbook::Helpers
   end


### PR DESCRIPTION
Currently getting a rash of warnings about invalid default values (String/Hash values defaulting to nil). This corrects those warnings.
