### PR TITLE
Make Fedora non-version specific for modules

### DIFF
--- a/libraries/info_module_packages.rb
+++ b/libraries/info_module_packages.rb
@@ -251,9 +251,9 @@ module HttpdCookbook
               found_in_package: ->(_name) { 'php' }
 
       #
-      # fedora-20
+      # fedora
       #
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(
                 access_compat actions alias allowmethods asis auth_basic
                 auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
@@ -275,7 +275,7 @@ module HttpdCookbook
               found_in_package: 'httpd'
 
       # predictable package naming
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(
                 auth_kerb dav_svn fcgid ldap nss proxy_html revocator security
                 session ssl wsgi
@@ -283,144 +283,28 @@ module HttpdCookbook
               found_in_package: ->(name) { "mod_#{name}" }
 
       # outliers
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(authz_svn dontdothat),
               found_in_package: ->(_name) { 'mod_dav_svn' }
 
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(authnz_ldap),
               found_in_package: ->(_name) { 'mod_ldap' }
 
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(xml2enc),
               found_in_package: ->(_name) { 'mod_proxy_html' }
 
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(rev),
               found_in_package: ->(_name) { 'mod_revocator' }
 
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(auth_form session_cookie session_crypto session_dbd),
               found_in_package: ->(_name) { 'mod_session' }
 
       # Yeah I don't get it either
-      modules for: { platform_family: 'fedora', platform_version: '20', httpd_version: '2.4' },
-              are: %w(php),
-              found_in_package: ->(_name) { 'php' }
-
-      #
-      # fedora-21
-      #
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(
-                access_compat actions alias allowmethods asis auth_basic
-                auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
-                authn_socache authz_core authz_dbd authz_dbm authz_groupfile
-                authz_host authz_owner authz_user autoindex buffer cache cache_disk
-                cache_socache cgi cgid charset_lite data dav dav_fs dav_lock dbd
-                deflate dialup dir dumpio echo env expires ext_filter file_cache
-                filter headers heartbeat heartmonitor include info
-                lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
-                lbmethod_heartbeat log_config log_debug log_forensic logio lua
-                macro mime mime_magic mpm_event mpm_prefork mpm_worker negotiation
-                proxy proxy_ajp proxy_balancer proxy_connect proxy_express
-                proxy_fcgi proxy_fdpass proxy_ftp proxy_http proxy_scgi
-                proxy_wstunnel ratelimit reflector remoteip reqtimeout request
-                rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
-                socache_memcache socache_shmcb speling status substitute suexec
-                systemd unique_id unixd userdir usertrack version vhost_alias watchdog
-              ),
-              found_in_package: 'httpd'
-
-      # predictable package naming
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(
-                auth_kerb dav_svn fcgid ldap nss proxy_html revocator security
-                session ssl wsgi
-              ),
-              found_in_package: ->(name) { "mod_#{name}" }
-
-      # outliers
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(authz_svn dontdothat),
-              found_in_package: ->(_name) { 'mod_dav_svn' }
-
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(authnz_ldap),
-              found_in_package: ->(_name) { 'mod_ldap' }
-
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(xml2enc),
-              found_in_package: ->(_name) { 'mod_proxy_html' }
-
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(rev),
-              found_in_package: ->(_name) { 'mod_revocator' }
-
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(auth_form session_cookie session_crypto session_dbd),
-              found_in_package: ->(_name) { 'mod_session' }
-
-      # Yeah I don't get it either
-      modules for: { platform_family: 'fedora', platform_version: '21', httpd_version: '2.4' },
-              are: %w(php),
-              found_in_package: ->(_name) { 'php' }
-
-      #
-      # fedora-22
-      #
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(
-                access_compat actions alias allowmethods asis auth_basic
-                auth_digest authn_anon authn_core authn_dbd authn_dbm authn_file
-                authn_socache authz_core authz_dbd authz_dbm authz_groupfile
-                authz_host authz_owner authz_user autoindex buffer cache cache_disk
-                cache_socache cgi cgid charset_lite data dav dav_fs dav_lock dbd
-                deflate dialup dir dumpio echo env expires ext_filter file_cache
-                filter headers heartbeat heartmonitor include info
-                lbmethod_bybusyness lbmethod_byrequests lbmethod_bytraffic
-                lbmethod_heartbeat log_config log_debug log_forensic logio lua
-                macro mime mime_magic mpm_event mpm_prefork mpm_worker negotiation
-                proxy proxy_ajp proxy_balancer proxy_connect proxy_express
-                proxy_fcgi proxy_fdpass proxy_ftp proxy_http proxy_scgi
-                proxy_wstunnel ratelimit reflector remoteip reqtimeout request
-                rewrite sed setenvif slotmem_plain slotmem_shm socache_dbm
-                socache_memcache socache_shmcb speling status substitute suexec
-                systemd unique_id unixd userdir usertrack version vhost_alias watchdog
-              ),
-              found_in_package: 'httpd'
-
-      # predictable package naming
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(
-                auth_kerb dav_svn fcgid ldap nss proxy_html revocator security
-                session ssl wsgi
-              ),
-              found_in_package: ->(name) { "mod_#{name}" }
-
-      # outliers
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(authz_svn dontdothat),
-              found_in_package: ->(_name) { 'mod_dav_svn' }
-
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(authnz_ldap),
-              found_in_package: ->(_name) { 'mod_ldap' }
-
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(xml2enc),
-              found_in_package: ->(_name) { 'mod_proxy_html' }
-
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(rev),
-              found_in_package: ->(_name) { 'mod_revocator' }
-
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
-              are: %w(auth_form session_cookie session_crypto session_dbd),
-              found_in_package: ->(_name) { 'mod_session' }
-
-      # Yeah I don't get it either
-      modules for: { platform_family: 'fedora', platform_version: '22', httpd_version: '2.4' },
+      modules for: { platform_family: 'fedora', httpd_version: '2.4' },
               are: %w(php),
               found_in_package: ->(_name) { 'php' }
 


### PR DESCRIPTION
### Description

Fedora releases often and has a very short release cycle.  Instead of adding release version information to the list of modules for Fedora releases we should just assume current. If someone is deploying on Fedora at this point they need to be on 22 or 23, which are the same. This reduces the complexity of the cookbook, and keeps us from being forced to release a new version every time a new Fedora release comes out.

### Issues Resolved

N/A

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD