### PR TITLE
Store systemd configs in /etc/systemd which is cross platform

### DIFF
--- a/libraries/httpd_service_rhel_systemd.rb
+++ b/libraries/httpd_service_rhel_systemd.rb
@@ -25,7 +25,7 @@ module HttpdCookbook
         action :create
       end
 
-      template "/usr/lib/systemd/system/#{apache_name}.service" do
+      template "/etc/systemd/system/#{apache_name}.service" do
         source 'systemd/httpd.service.erb'
         owner 'root'
         group 'root'
@@ -35,7 +35,7 @@ module HttpdCookbook
         action :create
       end
 
-      directory "/usr/lib/systemd/system/#{apache_name}.service.d" do
+      directory "/etc/systemd/system/#{apache_name}.service.d" do
         owner 'root'
         group 'root'
         mode '0755'


### PR DESCRIPTION
### Description

Suse doesn't include /usr/lib/systemd. This same change has been made to the Tomcat and and MySQL cookbooks. /etc/systemd is actually the highest level of unit configs and the one we should be using anyways.  Only packages should mess with the stuff in /usr/lib.

### Issues Resolved

N/A

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


