### PR TITLE
Fixed start timeout on ubuntu 16.04 and debian 8. Fixed kitchen tests on docker. 

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -19,7 +19,7 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install lsb-release -y
+      - RUN /usr/bin/apt-get install lsb-release net-tools -y
 
 - name: debian-8
   driver:
@@ -27,7 +27,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install lsb-release -y
+      - RUN /usr/bin/apt-get install lsb-release net-tools -y
 
 - name: centos-5
   driver:
@@ -51,14 +51,14 @@ platforms:
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install lsof which
+      - RUN yum -y install lsof which net-tools
 
 - name: fedora-23
   driver:
     image: fedora:23
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN dnf -y install yum which
+      - RUN dnf -y install yum which net-tools
 
 - name: ubuntu-12.04
   driver:
@@ -66,6 +66,7 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install -y net-tools
 
 - name: ubuntu-14.04
   driver:
@@ -80,6 +81,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install -y net-tools
 
 - name: opensuse-13.2
   driver:
@@ -87,6 +89,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN zypper refresh
+      - RUN zypper install -y net-tools
 
 suites:
   #

--- a/templates/default/systemd/httpd.service.erb
+++ b/templates/default/systemd/httpd.service.erb
@@ -3,7 +3,7 @@ Description=The Apache HTTP Server
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
-<% if node['platform'] == 'ubuntu' %>
+<% if %w(ubuntu debian).include? node['platform'] %>
 Type=simple
 <% else %>
 Type=notify

--- a/templates/default/systemd/httpd.service.erb
+++ b/templates/default/systemd/httpd.service.erb
@@ -3,7 +3,11 @@ Description=The Apache HTTP Server
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
+<% if node['platform'] == 'ubuntu' %>
+Type=simple
+<% else %>
 Type=notify
+<% end %>
 Environment=LANG=C
 
 ExecStart=/usr/sbin/<%= @binary_name %> -f /etc/<%= @apache_name %>/<%= @config_relative_path %> -DFOREGROUND

--- a/test/integration/module24/rhel_spec.rb
+++ b/test/integration/module24/rhel_spec.rb
@@ -1,11 +1,4 @@
 if os[:family] == 'centos' || os[:family] == 'fedora' || os[:family] == 'opensuse'
-  # auth_basic
-  describe file('/usr/lib64/httpd/modules/mod_auth_basic.so') do
-    it { should be_file }
-    its('mode') { should eq 00755 }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-  end
 
   describe file('/etc/httpd-default/conf.modules.d') do
     it { should be_directory }
@@ -17,14 +10,6 @@ if os[:family] == 'centos' || os[:family] == 'fedora' || os[:family] == 'opensus
   describe file('/etc/httpd-default/conf.modules.d/auth_basic.load') do
     it { should be_file }
     its('mode') { should eq 00644 }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-  end
-
-  # auth_kerb
-  describe file('/usr/lib64/httpd/modules/mod_expires.so') do
-    it { should be_file }
-    its('mode') { should eq 00755 }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
   end
@@ -43,3 +28,41 @@ if os[:family] == 'centos' || os[:family] == 'fedora' || os[:family] == 'opensus
     it { should be_grouped_into 'root' }
   end
 end
+
+if os[:family] == 'centos' || os[:family] == 'fedora'
+  # auth_basic
+  describe file('/usr/lib64/httpd/modules/mod_auth_basic.so') do
+    it { should be_file }
+    its('mode') { should eq 00755 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+  # auth_kerb
+  describe file('/usr/lib64/httpd/modules/mod_expires.so') do
+    it { should be_file }
+    its('mode') { should eq 00755 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+elsif os[:family] == 'opensuse'
+  # auth_basic
+  describe file('/usr/lib64/apache2/mod_auth_basic.so') do
+    it { should be_file }
+    its('mode') { should eq 00755 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+  # auth_kerb
+  describe file('/usr/lib64/apache2/mod_expires.so') do
+    it { should be_file }
+    its('mode') { should eq 00755 }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+  end
+
+end
+
+
+

--- a/test/integration/module24/rhel_spec.rb
+++ b/test/integration/module24/rhel_spec.rb
@@ -63,6 +63,3 @@ elsif os[:family] == 'opensuse'
   end
 
 end
-
-
-


### PR DESCRIPTION
### Description

Fix start timeout on ubuntu 16.04. 
Change systemd Service Type=notify to Type=simple on Ubuntu. Apache on ubuntu 16.04 does not come with systemd integration, so the type=notify can't be used. 
### Issues Resolved

[List any existing issues this PR resolves]
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

Apparently apache on Ubuntu 16.04 does not contain systemd support. This means that systemd Service type=notify can't be used.
This change adds a condition to the template so that Type=simple would be used on ubuntu.
