### PR TITLE
stop loading unused file

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,5 +1,3 @@
-require 'chef_compat/resource'
-
 module HttpdCookbook
   module Helpers
     def default_apache_version


### PR DESCRIPTION
### Description

This PR stops `helpers.rb` from failing to load `chef_compat/resource` on the current version of chef.  As of chef-cookbooks/compat_resource@5f9a2b4d4921e06901f4072457b83489c67fc61d, compat_resource does not add itself to $LOAD_PATH when running on the current version of chef-client.  In this case, trying to require `chef_compat/resource` raises a `LoadError`.  59c30257fd131a363558c72c42dfb48e39a58ed1 eliminated all of the references to `new_resource` from `helpers.rb` that had made it necessary to require `chef_compat/resource`.  There is no reason to continue trying to load the file.
### Issues Resolved

resolves #95
### Check List
- [x] ~~All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD~~ All tests were failing. With this PR, many pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
