### PR TITLE
Add net-tools so that InSpec can use `netstat`

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -19,7 +19,7 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install lsb-release -y
+      - RUN /usr/bin/apt-get install lsb-release net-tools -y
 
 - name: debian-8
   driver:
@@ -27,7 +27,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install lsb-release -y
+      - RUN /usr/bin/apt-get install lsb-release net-tools -y
 
 - name: centos-5
   driver:
@@ -51,14 +51,14 @@ platforms:
     platform: rhel
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN yum -y install lsof which
+      - RUN yum -y install lsof which net-tools
 
 - name: fedora-23
   driver:
     image: fedora:23
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
-      - RUN dnf -y install yum which
+      - RUN dnf -y install yum which net-tools
 
 - name: ubuntu-12.04
   driver:
@@ -66,6 +66,7 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install net-tools -y
 
 - name: ubuntu-14.04
   driver:
@@ -73,6 +74,7 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install net-tools -y
 
 - name: ubuntu-16.04
   driver:
@@ -80,6 +82,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install net-tools -y
 
 - name: opensuse-13.2
   driver:
@@ -87,6 +90,7 @@ platforms:
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN zypper refresh
+      - RUN zypper install -y net-tools
 
 suites:
   #


### PR DESCRIPTION
Added intermediate_instructions for the following instances:
- debian-7
- debian-8
- centos-7
- fedora-23
- ubuntu-12.04
- ubuntu-14.04
- unbutu-16.04
- opensuse-13.2

I suspect this will fix all of the current travis failures

Signed-off-by: Nathen Harvey nharvey@chef.io
