### PR TITLE
Explicitly specifying new_resource.version in guard

### DIFF
--- a/libraries/httpd_service_rhel.rb
+++ b/libraries/httpd_service_rhel.rb
@@ -117,7 +117,7 @@ module HttpdCookbook
         group 'root'
         mode '0755'
         recursive true
-        only_if { version.to_f >= 2.4 }
+        only_if { new_resource.version.to_f >= 2.4 }
         action :create
       end
 


### PR DESCRIPTION
Now in rhel, too

Fixes #97 although I've been unable to create a good test for a
regression.

Signed-off-by: Nathen Harvey nharvey@chef.io
