### PR TITLE
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # httpd Cookbook CHANGELOG
 
+## 0.4.5 (2017-02-13)
+- Resolve Issue #104 with use of security module on RHEL 7.2
+
 ## 0.4.4 (2016-09-27)
 - Explicitly using new_resource.version in guard clause Centos/RHEL
 - Add net-tools to docker configuration

--- a/libraries/info_module_packages.rb
+++ b/libraries/info_module_packages.rb
@@ -243,6 +243,10 @@ module HttpdCookbook
               found_in_package: ->(_name) { 'mod_revocator' }
 
       modules for: { platform_family: 'rhel', platform_version: '7', httpd_version: '2.4' },
+              are: %w(security2),
+              found_in_package: ->(_name) { 'mod_security' }
+
+      modules for: { platform_family: 'rhel', platform_version: '7', httpd_version: '2.4' },
               are: %w(auth_form session_cookie session_crypto session_dbd),
               found_in_package: ->(_name) { 'mod_session' }
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'httpd'
-version '0.4.4'
+version '0.4.5'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'


### PR DESCRIPTION
Updating module hints so that security2 can be used on RHEL 7.2 based on @kareiva's suggested fix.

### Description

Fixes mod_security module use on RHEL 7.2

### Issues Resolved

Issue #104 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
