### PR TITLE
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -173,7 +173,9 @@ suites:
         mpm: 'prefork'
         startservers: '20'
         minspareservers: '20'
-        minspareservers: '40'
+        maxspareservers: '40'
+        log_level: 'warn'
+        maxkeepaliverequests: '2001'
 
   #
   # service24-single
@@ -213,6 +215,7 @@ suites:
         version: '2.4'
         service_name: 'multi'
         listen_ports: [ '81', '444' ]
+        log_level: 'warn'
         run_user: 'bob'
         run_group: 'bob'
         contact: 'alice@computers.biz'
@@ -223,4 +226,5 @@ suites:
         mpm: 'prefork'
         startservers: '20'
         minspareservers: '20'
-        minspareservers: '40'
+        maxspareservers: '40'
+        maxkeepaliverequests: '2001'

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -105,6 +105,7 @@ suites:
         startservers: '20'
         minspareservers: '20'
         minspareservers: '40'
+        maxkeepaliverequests: '2001'
 
   #
   # service24-single
@@ -148,6 +149,7 @@ suites:
         version: '2.4'
         service_name: 'multi'
         listen_ports: [ '81', '444' ]
+        log_level: 'warn'
         run_user: 'bob'
         run_group: 'bob'
         contact: 'alice@computers.biz'
@@ -158,4 +160,6 @@ suites:
         mpm: 'worker'
         startservers: '20'
         minspareservers: '20'
-        minspareservers: '40'
+        maxspareservers: '40'
+        maxkeepaliverequests: '2001'
+

--- a/test/cookbooks/httpd_service_test/recipes/multi.rb
+++ b/test/cookbooks/httpd_service_test/recipes/multi.rb
@@ -47,7 +47,6 @@ httpd_service 'instance-2' do
   keepalive node['httpd']['keepalive']
   maxkeepaliverequests node['httpd']['maxkeepaliverequests']
   keepalivetimeout node['httpd']['keepalivetimeout']
-  listen_addresses node['httpd']['listen_addresses']
   listen_ports node['httpd']['listen_ports']
   log_level node['httpd']['log_level']
   version node['httpd']['version']


### PR DESCRIPTION


### Description
Chef 13 Remediations. Fixed the missing attributes from the kitchen configuration, and cleaned up the multi recipe to remove the listen_address attribute.

Deprecated features used!
  nil is an invalid value for maxkeepaliverequests of resource . In Chef 13, this warning will change to an error. Error: Property maxkeepaliverequests must be one of: String!  You passed nil. at 1 location:
    - /opt/kitchen/cache/cookbooks/httpd_service_test/recipes/multi.rb:48:in `block in from_file'
   See https://docs.chef.io/deprecations_custom_resource_cleanups.html for further details.
  nil is an invalid value for listen_addresses of resource . In Chef 13, this warning will change to an error. Error: Property listen_addresses must be one of: String, Array!  You passed nil. at 1 location:
    - /opt/kitchen/cache/cookbooks/httpd_service_test/recipes/multi.rb:50:in `block in from_file'
   See https://docs.chef.io/deprecations_custom_resource_cleanups.html for further details.
  nil is an invalid value for log_level of resource . In Chef 13, this warning will change to an error. Error: Property log_level must be one of: String!  You passed nil. at 1 location:
    - /opt/kitchen/cache/cookbooks/httpd_service_test/recipes/multi.rb:52:in `block in from_file'
   See https://docs.chef.io/deprecations_custom_resource_cleanups.html for further details.
  An attempt was made to change maxspareservers from "10" to nil by calling maxspareservers(nil). In Chef 12, this does a get rather than a set. In Chef 13, this will change to set the value to nil. at 1 location:
    - /opt/kitchen/cache/cookbooks/httpd_service_test/recipes/multi.rb:60:in `block in from_file'
   See https://docs.chef.io/deprecations_custom_resource_cleanups.html for further details.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
