### PR TITLE
Remove test for debian platform as apt_update is a noop on non-debian platforms

### DIFF
--- a/test/cookbooks/hello_world_test/recipes/default-docker.rb
+++ b/test/cookbooks/hello_world_test/recipes/default-docker.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 httpd_service 'default' do
   action :create

--- a/test/cookbooks/hello_world_test/recipes/default.rb
+++ b/test/cookbooks/hello_world_test/recipes/default.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 httpd_service 'default' do
   action [:create, :start]

--- a/test/cookbooks/httpd_config_test/recipes/default.rb
+++ b/test/cookbooks/httpd_config_test/recipes/default.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 httpd_config 'hello' do
   instance 'default'

--- a/test/cookbooks/httpd_module_test/recipes/default.rb
+++ b/test/cookbooks/httpd_module_test/recipes/default.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 httpd_module 'auth_basic' do
   httpd_version node['httpd']['version']

--- a/test/cookbooks/httpd_service_test/recipes/multi.rb
+++ b/test/cookbooks/httpd_service_test/recipes/multi.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 group 'alice' do
   action :create

--- a/test/cookbooks/httpd_service_test/recipes/single.rb
+++ b/test/cookbooks/httpd_service_test/recipes/single.rb
@@ -1,4 +1,4 @@
-apt_update 'update' if platform_family?('debian')
+apt_update 'update'
 
 httpd_service node['httpd']['service_name'] do
   action [:create, :start]


### PR DESCRIPTION

### Description

Remove test for debian platform as apt_update is a noop on non-debian platforms

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
