### PR TITLE
Don't delete directory mods-available with delete action.

### DIFF
--- a/libraries/httpd_module_debian.rb
+++ b/libraries/httpd_module_debian.rb
@@ -45,11 +45,6 @@ module HttpdCookbook
     end
 
     action :delete do
-      directory "/etc/#{apache_name}/mods-available" do
-        recursive true
-        action :delete
-      end
-
       file "/etc/#{apache_name}/mods-available/#{new_resource.module_name}.load" do
         action :delete
       end


### PR DESCRIPTION


### Description

Remove directory resource from being deleted with delete action as can be impactful to other modules that may be configured/enabled.

### Issues Resolved

#115 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
