### PR TITLE
Add a missing service name variable on RHEL platforms

### DIFF
--- a/libraries/httpd_service_rhel_systemd.rb
+++ b/libraries/httpd_service_rhel_systemd.rb
@@ -40,7 +40,7 @@ module HttpdCookbook
 
     action_class do
       def create_stop_system_service
-        service 'httpd' do
+        service apache_name do
           provider Chef::Provider::Service::Init::Systemd
           action [:stop, :disable]
         end


### PR DESCRIPTION
This will eventually get us to the point where we support SUSE

Signed-off-by: Tim Smith <tsmith@chef.io>