### PR TITLE
Allow sensitive config

### DIFF
--- a/libraries/httpd_config_debian.rb
+++ b/libraries/httpd_config_debian.rb
@@ -20,6 +20,7 @@ module HttpdCookbook
           variables(new_resource.variables)
           source new_resource.source
           cookbook new_resource.cookbook
+          sensitive new_resource.sensitive if new_resource.sensitive
           action :create
         end
       else
@@ -38,6 +39,7 @@ module HttpdCookbook
           variables(new_resource.variables)
           source new_resource.source
           cookbook new_resource.cookbook
+          sensitive new_resource.sensitive if new_resource.sensitive
           action :create
         end
 

--- a/libraries/httpd_config_rhel.rb
+++ b/libraries/httpd_config_rhel.rb
@@ -19,6 +19,7 @@ module HttpdCookbook
         variables(new_resource.variables)
         source new_resource.source
         cookbook new_resource.cookbook
+        sensitive new_resource.sensitive if new_resource.sensitive
         action :create
       end
     end

--- a/test/cookbooks/httpd_config_test/recipes/default.rb
+++ b/test/cookbooks/httpd_config_test/recipes/default.rb
@@ -11,3 +11,12 @@ httpd_config 'hello_again' do
   source 'hello.conf.erb'
   action :create
 end
+
+httpd_config 'sensitive' do
+  instance 'sensitive'
+  source 'sensitive.conf.erb'
+  sensitive true
+  variables(
+    password: 'should_be_hidden')
+  action :create
+end

--- a/test/cookbooks/httpd_config_test/templates/default/sensitive.conf.erb
+++ b/test/cookbooks/httpd_config_test/templates/default/sensitive.conf.erb
@@ -1,0 +1,4 @@
+# hidden test
+<% if @password %>
+password <%= @password %>
+<% end %>


### PR DESCRIPTION
### Description

Allow `sensitive` option for the `httpd_config` resource to obfuscate sensitive data.

### Issues Resolved

Resolves #114 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
