### PR TITLE
Remove resource duplication in httpd_service_rhel_systemd

### DIFF
--- a/libraries/httpd_service_rhel_systemd.rb
+++ b/libraries/httpd_service_rhel_systemd.rb
@@ -40,7 +40,8 @@ module HttpdCookbook
 
     action_class do
       def create_stop_system_service
-        service apache_name do
+        service 'apache service' do
+          service_name apache_name
           provider Chef::Provider::Service::Init::Systemd
           action [:stop, :disable]
         end


### PR DESCRIPTION
### Description

Remove the resource duplications in `httpd_service_rhel_systemd` library

### Issues Resolved

```
       Deprecated features used!
         Cloning resource attributes for service[httpd-default] from prior resource (CHEF-3694)
       Previous service[httpd-default]: /tmp/kitchen/cache/cookbooks/httpd/libraries/httpd_service_rhel_systemd.rb:43:in `create_stop_system_service'
       Current  service[httpd-default]: /tmp/kitchen/cache/cookbooks/httpd/libraries/httpd_service_rhel_systemd.rb:100:in `create_setup_service' at 1 location:
           - /tmp/kitchen/cache/cookbooks/poise/files/halite_gem/poise/helpers/resource_cloning.rb:58:in `emit_cloned_resource_warning'
```
This changes helps to resolve this deprecated message and helps to move to Chef 13+

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
